### PR TITLE
fix: improve daily dish generation reliability

### DIFF
--- a/scripts/agents/propose-dish.ts
+++ b/scripts/agents/propose-dish.ts
@@ -1,5 +1,4 @@
 import OpenAI from "openai";
-import { getCountryNames } from "../../src/utils/countries";
 
 function createOpenAI() {
   const apiKey = process.env.OPENAI_API_KEY;
@@ -7,42 +6,69 @@ function createOpenAI() {
   return new OpenAI({ apiKey });
 }
 
-export async function proposeDishCandidates(options: {
-  existingNormalized: string[]; // normalized names/guesses
-  maxSuggestions?: number;
-}): Promise<Array<{ name: string; country: string }>> {
-  const { existingNormalized, maxSuggestions = 3 } = options;
+export interface ProposeDishOptions {
+  /** List of countries to choose dishes from (human-readable, e.g., "Italy", "Japan") */
+  countries: string[];
+  /** List of dish names to avoid (human-readable, e.g., "Beef Bulgogi", "Pad Thai") */
+  blockedDishes: string[];
+  /** Number of dishes to suggest */
+  maxSuggestions: number;
+}
 
-  const validCountries = getCountryNames().join(", ");
+/**
+ * Propose dish candidates using AI.
+ * Uses human-readable country names and dish names (not normalized).
+ */
+export async function proposeDishCandidates(
+  options: ProposeDishOptions
+): Promise<Array<{ name: string; country: string }>> {
+  const { countries, blockedDishes, maxSuggestions } = options;
 
-  const instruction = `You propose dish candidates for a food guessing game.
-Constraints:
-- Only propose dishes that are NOT in the provided existing list (normalized tokens, no spaces/punctuation).
-- Return ${maxSuggestions} diverse, globally distributed dishes.
-- Each item must include a clean dish name (no country words in the name) and a Title Case country of origin.
-- IMPORTANT: Dish names must have proper spacing between words (e.g., "Pasta Fagioli" not "PastaFagioli", "Beef Bulgogi" not "BeefBulgogi").
-- The country MUST be one of the following: ${validCountries}
-- Output ONLY a compact JSON array of {"name":"...","country":"..."} objects. No extra text.`;
+  const countriesList = countries.join(", ");
+  const blockedList = blockedDishes.join(", ");
 
-  const existingList = existingNormalized.slice(0, 400).join(",");
+  const instruction = `You are proposing dish candidates for a food guessing game.
+
+TASK: Suggest ${maxSuggestions} traditional dishes from the following countries.
+
+ALLOWED COUNTRIES (choose dishes ONLY from these):
+${countriesList}
+
+BLOCKED DISHES (do NOT suggest any of these):
+${blockedList}
+
+REQUIREMENTS:
+- Each dish must be a real, traditional dish from one of the allowed countries
+- Dish names must have proper spacing (e.g., "Pad Thai" not "PadThai")
+- Do NOT include country names or nationality words in the dish name
+- Return diverse dishes across different countries when possible
+- Output ONLY a JSON array: [{"name": "Dish Name", "country": "Country"}]
+- No markdown, no explanation, just the JSON array`;
 
   const messages = [
     {
       role: "user" as const,
-      content: `${instruction}\n\nEXISTING_NORMALIZED_LIST=${existingList}`,
+      content: instruction,
     },
   ];
 
   const openai = createOpenAI();
+
+  console.log(
+    `🤖 Proposing ${maxSuggestions} dishes from ${countries.length} countries (blocking ${blockedDishes.length} dishes)`
+  );
+
   const resp = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    temperature: 0.4,
-    max_tokens: 400,
+    model: "gpt-4.1-nano",
+    temperature: 0.6,
+    max_tokens: 800,
     messages,
   });
 
   const content = resp.choices[0]?.message?.content?.trim() || "[]";
   let json = content;
+
+  // Strip markdown code blocks if present
   if (json.startsWith("```")) {
     json = json.replace(/^```[a-zA-Z]*\n?/, "").replace(/```\s*$/, "");
   }
@@ -50,11 +76,26 @@ Constraints:
   try {
     const parsed = JSON.parse(json);
     if (Array.isArray(parsed)) {
-      return parsed
-        .filter((x) => x && x.name && x.country)
-        .slice(0, maxSuggestions);
+      const valid = parsed
+        .filter(
+          (x) =>
+            x &&
+            typeof x.name === "string" &&
+            typeof x.country === "string" &&
+            x.name.trim() &&
+            x.country.trim()
+        )
+        .map((x) => ({
+          name: x.name.trim(),
+          country: x.country.trim(),
+        }));
+
+      console.log(`✅ AI proposed ${valid.length} dishes`);
+      return valid;
     }
-  } catch {}
+  } catch (e) {
+    console.error("❌ Failed to parse AI response:", e);
+  }
 
   return [];
 }

--- a/scripts/agents/propose-dish.ts
+++ b/scripts/agents/propose-dish.ts
@@ -59,7 +59,7 @@ REQUIREMENTS:
   );
 
   const resp = await openai.chat.completions.create({
-    model: "gpt-4.1-nano",
+    model: "gpt-4o-mini",
     temperature: 0.6,
     max_tokens: 800,
     messages,

--- a/scripts/daily-generate.ts
+++ b/scripts/daily-generate.ts
@@ -7,7 +7,7 @@ import path from "path";
 import AIService from "../src/services/aiService";
 import DishImageService from "../src/services/dishImageService";
 import { getCountryCoordsMap } from "../src/utils/countries";
-// Deterministic evaluator: simple structural rules to avoid noisy LLM rejections
+import { sampleCountriesWeighted } from "../src/data/continentGroups";
 import { proposeDishCandidates } from "./agents/propose-dish";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -20,17 +20,21 @@ if (!supabaseUrl || !supabaseServiceKey) {
   process.exit(1);
 }
 
-const DAILY_COST_CAP_USD = parseFloat(process.env.DAILY_COST_CAP_USD || "0.25");
+// Configuration
 const TARGET_BUFFER_DAYS = parseInt(process.env.TARGET_BUFFER_DAYS || "14", 10);
+const RECENT_DAYS_BLOCK = parseInt(process.env.RECENT_DAYS_BLOCK || "60", 10);
+const MAX_DISHES_PER_RUN = 10;
+const DAILY_COST_CAP_USD = parseFloat(process.env.DAILY_COST_CAP_USD || "0.50");
 
-function normalize(s: string) {
+// Utility functions
+function normalize(s: string): string {
   return (s || "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "")
     .trim();
 }
 
-function titleCase(s: string) {
+function titleCase(s: string): string {
   return (s || "")
     .toLowerCase()
     .split(/\s+/)
@@ -38,93 +42,86 @@ function titleCase(s: string) {
     .join(" ");
 }
 
-async function loadExistingDishes(supabase: any) {
+// Types
+type Candidate = {
+  name: string;
+  country: string;
+  source: "backlog" | "ai";
+  existsInDb: boolean;
+};
+
+type DishRecord = {
+  id: number;
+  name: string;
+  acceptable_guesses: string[] | null;
+  country: string;
+  release_date: string;
+};
+
+// Database queries
+async function queryFutureDishes(supabase: any): Promise<DishRecord[]> {
+  const today = new Date().toISOString().split("T")[0];
   const { data, error } = await supabase
     .from("dishes")
-    .select(
-      "id,name,acceptable_guesses,country,release_date,image_url,fun_fact"
-    )
+    .select("id,name,acceptable_guesses,country,release_date")
+    .gte("release_date", today);
+  if (error) throw error;
+  return data || [];
+}
+
+async function queryPastDishesFromCountries(
+  supabase: any,
+  countries: string[]
+): Promise<DishRecord[]> {
+  const today = new Date().toISOString().split("T")[0];
+  const { data, error } = await supabase
+    .from("dishes")
+    .select("id,name,acceptable_guesses,country,release_date")
+    .lt("release_date", today)
+    .in("country", countries);
+  if (error) throw error;
+  return data || [];
+}
+
+async function queryRecentDishes(
+  supabase: any,
+  days: number
+): Promise<DishRecord[]> {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const cutoffStr = cutoff.toISOString().split("T")[0];
+  const { data, error } = await supabase
+    .from("dishes")
+    .select("id,name,acceptable_guesses,country,release_date")
+    .gte("release_date", cutoffStr);
+  if (error) throw error;
+  return data || [];
+}
+
+async function queryAllDishes(supabase: any): Promise<DishRecord[]> {
+  const { data, error } = await supabase
+    .from("dishes")
+    .select("id,name,acceptable_guesses,country,release_date")
     .order("release_date", { ascending: false });
   if (error) throw error;
   return data || [];
 }
 
-type Candidate = {
-  name: string;
-  country?: string;
-  source: "arg" | "backlog" | "ai";
-};
-
-async function buildCandidateQueue(existing: any[]): Promise<Candidate[]> {
-  const queue: Candidate[] = [];
-  const argName = process.argv.slice(2).join(" ");
-  if (argName) queue.push({ name: argName, source: "arg" });
-
-  const backlogPath = path.resolve(__dirname, "../src/data/dish_backlog.json");
-  let backlog: Array<{ name: string; country?: string }> = [];
-  if (fs.existsSync(backlogPath)) {
-    backlog = JSON.parse(fs.readFileSync(backlogPath, "utf-8"));
-  }
-  // Take up to first 5 backlog items to try this run
-  for (const item of backlog.slice(0, 5)) {
-    queue.push({ name: item.name, country: item.country, source: "backlog" });
-  }
-
-  // Always fetch AI proposals (cheap) and append
-  const normalizedExisting = new Set<string>();
-  for (const d of existing) {
-    normalizedExisting.add(normalize(d.name));
-    const guesses: string[] = d.acceptable_guesses || [];
-    for (const g of guesses) normalizedExisting.add(normalize(g));
-  }
-  const proposals = await proposeDishCandidates({
-    existingNormalized: Array.from(normalizedExisting),
-    maxSuggestions: 10,
-  });
-  for (const p of proposals) {
-    queue.push({ name: p.name, country: p.country, source: "ai" });
-  }
-
-  // De-duplicate by normalized name
-  const seen = new Set<string>();
-  const deduped: Candidate[] = [];
-  for (const c of queue) {
-    const key = normalize(c.name);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(c);
-  }
-  return deduped;
-}
-
-function removeFromBacklog(consumedName: string) {
-  const backlogPath = path.resolve(__dirname, "../src/data/dish_backlog.json");
-  if (!fs.existsSync(backlogPath)) return;
-  const backlog = JSON.parse(fs.readFileSync(backlogPath, "utf-8")) as Array<{
-    name: string;
-    country?: string;
-  }>;
-  const remaining = backlog.filter(
-    (x) => normalize(x.name) !== normalize(consumedName)
+async function countBufferDays(supabase: any): Promise<number> {
+  const today = new Date().toISOString().split("T")[0];
+  const { data, error } = await supabase
+    .from("dishes")
+    .select("release_date")
+    .gte("release_date", today)
+    .order("release_date", { ascending: true });
+  if (error || !data) return 0;
+  const last = data[data.length - 1]?.release_date;
+  if (!last) return 0;
+  const diff = Math.ceil(
+    (new Date(String(last)).getTime() - new Date(today).getTime()) /
+      (1000 * 60 * 60 * 24)
   );
-  fs.writeFileSync(backlogPath, JSON.stringify(remaining, null, 2));
-}
-
-function isDuplicate(candidate: string, existing: any[]): boolean {
-  const cand = normalize(candidate);
-  for (const dish of existing) {
-    if (normalize(dish.name) === cand) return true;
-    const guesses: string[] = dish.acceptable_guesses || [];
-    if (guesses.some((g) => normalize(g) === cand)) return true;
-  }
-  return false;
-}
-
-function countryValid(country?: string): boolean {
-  if (!country) return true; // optional on backlog
-  const coords = getCountryCoordsMap();
-  const key = (country || "").toLowerCase().replace(/\s+/g, "");
-  return Boolean(coords[key]);
+  return Math.max(diff, 0);
 }
 
 async function getNextReleaseDate(supabase: any): Promise<string> {
@@ -141,381 +138,478 @@ async function getNextReleaseDate(supabase: any): Promise<string> {
   return base.toISOString().split("T")[0];
 }
 
-async function countBufferDays(supabase: any): Promise<number> {
-  const today = new Date().toISOString().split("T")[0];
-  const { data, error } = await supabase
-    .from("dishes")
-    .select("release_date")
-    .gte("release_date", today)
-    .order("release_date", { ascending: true });
-  if (error || !data) return 0;
-  // days scheduled from today inclusive
-  const last = data[data.length - 1]?.release_date as any;
-  if (!last) return 0;
-  const diff = Math.ceil(
-    (new Date(String(last)).getTime() - new Date(today).getTime()) /
-      (1000 * 60 * 60 * 24)
-  );
-  return Math.max(diff, 0);
+// Build blocked dishes list (human-readable names)
+function buildBlockedDishList(dishes: DishRecord[]): string[] {
+  const names = new Set<string>();
+  for (const dish of dishes) {
+    names.add(dish.name);
+    // Also add acceptable guesses
+    if (dish.acceptable_guesses) {
+      for (const guess of dish.acceptable_guesses) {
+        names.add(guess);
+      }
+    }
+  }
+  return Array.from(names);
 }
 
-async function main() {
-  const supabase: any = createClient(supabaseUrl!, supabaseServiceKey!);
-  const existing = await loadExistingDishes(supabase);
+// Check if a candidate is blocked (using normalized comparison)
+function isBlocked(candidateName: string, blockedList: string[]): boolean {
+  const normCandidate = normalize(candidateName);
+  return blockedList.some((blocked) => normalize(blocked) === normCandidate);
+}
 
+// Check if dish exists in full database
+function existsInDatabase(candidateName: string, allDishes: DishRecord[]): boolean {
+  const normCandidate = normalize(candidateName);
+  for (const dish of allDishes) {
+    if (normalize(dish.name) === normCandidate) return true;
+    if (dish.acceptable_guesses) {
+      for (const guess of dish.acceptable_guesses) {
+        if (normalize(guess) === normCandidate) return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Load backlog from file
+function loadBacklog(): Array<{ name: string; country?: string }> {
+  const backlogPath = path.resolve(__dirname, "../src/data/dish_backlog.json");
+  if (!fs.existsSync(backlogPath)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(backlogPath, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+function removeFromBacklog(consumedName: string): void {
+  const backlogPath = path.resolve(__dirname, "../src/data/dish_backlog.json");
+  if (!fs.existsSync(backlogPath)) return;
+  try {
+    const backlog = JSON.parse(fs.readFileSync(backlogPath, "utf-8")) as Array<{
+      name: string;
+      country?: string;
+    }>;
+    const remaining = backlog.filter(
+      (x) => normalize(x.name) !== normalize(consumedName)
+    );
+    fs.writeFileSync(backlogPath, JSON.stringify(remaining, null, 2));
+  } catch {}
+}
+
+// Validate country has coordinates
+function countryValid(country: string): boolean {
+  if (!country) return false;
+  const coords = getCountryCoordsMap();
+  const key = country.toLowerCase().replace(/\s+/g, "");
+  return Boolean(coords[key]);
+}
+
+// Deterministic evaluation of generated dish
+function deterministicEvaluate(draft: {
+  name: string;
+  country: string;
+  ingredients: string[];
+  blurb: string;
+  proteinPerServing: number;
+  recipe: { ingredients: string[]; instructions: string[] };
+  tags: string[];
+}): { accept: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+  const countryOk = /^[A-Z][a-z]*(\s[A-Z][a-z]*)*$/.test(draft.country);
+  if (!countryOk) reasons.push("country not Title Case");
+  const blurbHasCountry = new RegExp(`\\b${draft.country}\\b`, "i").test(
+    draft.blurb || ""
+  );
+  if (blurbHasCountry) reasons.push("blurb contains country");
+  if (!draft.ingredients || draft.ingredients.length !== 6)
+    reasons.push("ingredients must be exactly 6");
+  if (!draft.recipe || (draft.recipe.ingredients || []).length < 6)
+    reasons.push("recipe.ingredients must be >= 6");
+  if (!draft.recipe || (draft.recipe.instructions || []).length < 6)
+    reasons.push("instructions must be >= 6 steps");
+  if (!draft.tags || draft.tags.length < 3 || draft.tags.length > 6)
+    reasons.push("tags must be 3-6 items");
+  return { accept: reasons.length === 0, reasons };
+}
+
+function stripCountryFromBlurb(blurb: string, country: string): string {
+  let b = blurb || "";
+  const words = (country || "")
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .filter(Boolean);
+  for (const w of words) {
+    b = b.replace(new RegExp(`\\b${w}\\b`, "gi"), " ");
+  }
+  if (country) b = b.replace(new RegExp(`\\b${country}\\b`, "gi"), " ");
+  return b.replace(/\s{2,}/g, " ").trim();
+}
+
+// Main function
+async function main() {
+  const supabase = createClient(supabaseUrl!, supabaseServiceKey!);
+
+  // Step 1: Check buffer and calculate how many dishes we need
   const bufferDays = await countBufferDays(supabase);
   console.log(
-    `📅 Current scheduled buffer: ${bufferDays} days (target ${TARGET_BUFFER_DAYS})`
+    `📅 Current buffer: ${bufferDays} days (target: ${TARGET_BUFFER_DAYS})`
   );
+
   if (bufferDays >= TARGET_BUFFER_DAYS) {
     console.log("✅ Buffer sufficient. Skipping generation.");
     return;
   }
 
-  let spent = 0;
-  const maxSpend = DAILY_COST_CAP_USD;
+  const dishesNeeded = TARGET_BUFFER_DAYS - bufferDays;
+  const dishesToRequest = Math.min(dishesNeeded + 5, MAX_DISHES_PER_RUN);
+  console.log(`🎯 Need ${dishesNeeded} dishes, requesting ${dishesToRequest} from AI`);
 
-  const candidates = await buildCandidateQueue(existing);
-  if (candidates.length === 0) {
-    console.log("⚠️ No candidate found (args/backlog/AI). Skipping.");
+  // Step 2: Sample countries (15 total with weighted distribution)
+  const sampledCountries = sampleCountriesWeighted();
+  console.log(`🌍 Sampled ${sampledCountries.length} countries:`, sampledCountries.join(", "));
+
+  // Step 3: Build DISHES_BLOCKED_LIST
+  console.log("\n📋 Building blocked dishes list...");
+
+  // Query A: Future/buffer dishes
+  const futureDishes = await queryFutureDishes(supabase);
+  console.log(`  - Future dishes: ${futureDishes.length}`);
+
+  // Query B: Past dishes from sampled countries
+  const pastFromSampledCountries = await queryPastDishesFromCountries(
+    supabase,
+    sampledCountries
+  );
+  console.log(`  - Past dishes from sampled countries: ${pastFromSampledCountries.length}`);
+
+  // Query C: Recent dishes (any country, last N days)
+  const recentDishes = await queryRecentDishes(supabase, RECENT_DAYS_BLOCK);
+  console.log(`  - Recent dishes (last ${RECENT_DAYS_BLOCK} days): ${recentDishes.length}`);
+
+  // Combine and deduplicate
+  const allBlockedDishes = [
+    ...futureDishes,
+    ...pastFromSampledCountries,
+    ...recentDishes,
+  ];
+  const blockedDishNames = buildBlockedDishList(allBlockedDishes);
+  console.log(`  - Total blocked dish names: ${blockedDishNames.length}`);
+
+  // Also query full database for existence check (used in sorting)
+  const allDishes = await queryAllDishes(supabase);
+  console.log(`  - Total dishes in database: ${allDishes.length}`);
+
+  // Step 4: Get AI proposals
+  console.log("\n🤖 Getting AI dish proposals...");
+  const aiProposals = await proposeDishCandidates({
+    countries: sampledCountries,
+    blockedDishes: blockedDishNames,
+    maxSuggestions: dishesToRequest,
+  });
+
+  // Step 4b: Load backlog items
+  const backlog = loadBacklog();
+  console.log(`📦 Backlog items: ${backlog.length}`);
+
+  // Build candidate list: backlog first, then AI proposals
+  const candidates: Candidate[] = [];
+
+  // Add backlog items (filtered, with country validation)
+  for (const item of backlog) {
+    if (!item.country || !countryValid(item.country)) continue;
+    candidates.push({
+      name: item.name,
+      country: item.country,
+      source: "backlog",
+      existsInDb: existsInDatabase(item.name, allDishes),
+    });
+  }
+
+  // Add AI proposals
+  for (const proposal of aiProposals) {
+    if (!countryValid(proposal.country)) continue;
+    candidates.push({
+      name: proposal.name,
+      country: proposal.country,
+      source: "ai",
+      existsInDb: existsInDatabase(proposal.name, allDishes),
+    });
+  }
+
+  // Deduplicate by normalized name
+  const seen = new Set<string>();
+  const dedupedCandidates: Candidate[] = [];
+  for (const c of candidates) {
+    const key = normalize(c.name);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dedupedCandidates.push(c);
+  }
+
+  console.log(`\n📝 Total candidates before filtering: ${dedupedCandidates.length}`);
+
+  // Step 5: Filter and sort candidates
+  // 5a: Filter OUT any dish in DISHES_BLOCKED_LIST
+  const filteredCandidates = dedupedCandidates.filter((c) => {
+    const blocked = isBlocked(c.name, blockedDishNames);
+    if (blocked) {
+      console.log(`  ⛔ Blocked: ${c.name}`);
+    }
+    return !blocked;
+  });
+
+  if (filteredCandidates.length === 0) {
+    console.log("\n⚠️ All suggested dishes are in the blocked list. No dishes to generate.");
     return;
   }
 
+  // 5b: Sort - new dishes first, existing (repeatable) dishes last
+  filteredCandidates.sort((a, b) => {
+    // New dishes (existsInDb = false) come first
+    if (a.existsInDb !== b.existsInDb) {
+      return a.existsInDb ? 1 : -1;
+    }
+    // Backlog items come before AI items within same category
+    if (a.source !== b.source) {
+      return a.source === "backlog" ? -1 : 1;
+    }
+    return 0;
+  });
+
+  // 5c: Take only as many as needed
+  const candidatesToGenerate = filteredCandidates.slice(0, dishesNeeded);
+  console.log(`\n🎯 Will attempt to generate ${candidatesToGenerate.length} dishes:`);
+  for (const c of candidatesToGenerate) {
+    const status = c.existsInDb ? "(repeat)" : "(new)";
+    console.log(`  - ${c.name} [${c.country}] ${status} (${c.source})`);
+  }
+
+  // Step 6: Generation loop
   const ai = new AIService();
   const imageService = new DishImageService();
-  let generated: any = null;
-  let usedCandidate: Candidate | null = null;
+  let successCount = 0;
+  let spent = 0;
+  let nextReleaseDate = await getNextReleaseDate(supabase);
 
-  const toTitleCase = (s: string) =>
-    (s || "")
-      .toLowerCase()
-      .split(/\s+/)
-      .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
-      .join(" ");
+  for (const candidate of candidatesToGenerate) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`🔄 Generating: ${candidate.name} (${candidate.country})`);
 
-  const stripCountryFromBlurb = (blurb: string, country: string) => {
-    let b = blurb || "";
-    const words = (country || "")
-      .toLowerCase()
-      .split(/[^a-z]+/)
-      .filter(Boolean);
-    for (const w of words) {
-      b = b.replace(new RegExp(`\\b${w}\\b`, "gi"), " ");
+    // Check budget
+    if (spent >= DAILY_COST_CAP_USD) {
+      console.log(`⚠️ Budget exhausted ($${spent.toFixed(2)}). Stopping.`);
+      break;
     }
-    if (country) b = b.replace(new RegExp(`\\b${country}\\b`, "gi"), " ");
-    return b.replace(/\s{2,}/g, " ").trim();
-  };
 
-  const deterministicEvaluate = (draft: {
-    name: string;
-    country: string;
-    ingredients: string[];
-    blurb: string;
-    proteinPerServing: number;
-    recipe: { ingredients: string[]; instructions: string[] };
-    tags: string[];
-  }): { accept: boolean; reasons: string[] } => {
-    const reasons: string[] = [];
-    const countryOk = /^[A-Z][a-z]*(\s[A-Z][a-z]*)*$/.test(draft.country);
-    if (!countryOk) reasons.push("country not Title Case");
-    const blurbHasCountry = new RegExp(`\\b${draft.country}\\b`, "i").test(
-      draft.blurb || ""
-    );
-    if (blurbHasCountry) reasons.push("blurb contains country");
-    if (!draft.ingredients || draft.ingredients.length !== 6)
-      reasons.push("ingredients must be exactly 6");
-    if (!draft.recipe || (draft.recipe.ingredients || []).length < 6)
-      reasons.push("recipe.ingredients must be >= 6");
-    if (!draft.recipe || (draft.recipe.instructions || []).length < 6)
-      reasons.push("instructions must be >= 6 steps");
-    if (!draft.tags || draft.tags.length < 3 || draft.tags.length > 6)
-      reasons.push("tags must be 3-6 items");
-    const accept = reasons.length === 0;
-    return { accept, reasons };
-  };
+    try {
+      // Generate dish text
+      const textOnly = await ai.generateCompleteDish(candidate.name);
+      if (!textOnly) {
+        console.log("❌ Text generation failed, skipping.");
+        if (candidate.source === "backlog") removeFromBacklog(candidate.name);
+        continue;
+      }
 
-  for (const cand of candidates) {
-    console.log(`🔎 Trying candidate: ${cand.name} (${cand.source})`);
-    if (isDuplicate(cand.name, existing)) {
-      console.log(`⚠️ Duplicate found, skipping: ${cand.name}`);
-      if (cand.source === "backlog") removeFromBacklog(cand.name);
-      continue;
-    }
-    if (cand.country && !countryValid(cand.country)) {
-      console.log(
-        `❌ Invalid country for ${cand.name}: ${cand.country}. Skipping.`
+      // Sanitize
+      const countryTitle = titleCase(textOnly.country || candidate.country);
+      const sanitizedBlurb = stripCountryFromBlurb(
+        textOnly.blurb || "",
+        countryTitle
       );
-      if (cand.source === "backlog") removeFromBacklog(cand.name);
-      continue;
-    }
+      const sanitizedTopIngredients = (textOnly.ingredients || []).slice(0, 6);
 
-    const textOnly = await ai.generateCompleteDish(cand.name);
-    if (!textOnly) {
-      console.log("❌ Text generation failed, trying next candidate.");
-      if (cand.source === "backlog") removeFromBacklog(cand.name);
-      continue;
-    }
+      // Evaluate
+      const evalResult = deterministicEvaluate({
+        name: textOnly.name,
+        country: countryTitle,
+        ingredients: sanitizedTopIngredients,
+        blurb: sanitizedBlurb,
+        proteinPerServing: textOnly.proteinPerServing,
+        recipe: textOnly.recipe,
+        tags: textOnly.tags,
+      });
 
-    // Sanitize before evaluation
-    const countryTitle = toTitleCase(textOnly.country || "");
-    const sanitizedBlurb = stripCountryFromBlurb(
-      textOnly.blurb || "",
-      countryTitle
-    );
-    const sanitizedTopIngredients = (textOnly.ingredients || []).slice(0, 6);
-
-    const evalResult = deterministicEvaluate({
-      name: textOnly.name,
-      country: countryTitle,
-      ingredients: sanitizedTopIngredients,
-      blurb: sanitizedBlurb,
-      proteinPerServing: textOnly.proteinPerServing,
-      recipe: textOnly.recipe,
-      tags: textOnly.tags,
-    });
-    if (!evalResult.accept) {
-      console.log("❌ Evaluator rejected:", evalResult.reasons.join("; "));
-      if (cand.source === "backlog") removeFromBacklog(cand.name);
-      continue;
-    }
-
-    const imageResult = await imageService.generateDishImage({
-      name: textOnly.name,
-      ingredients: sanitizedTopIngredients,
-      country: countryTitle,
-      blurb: sanitizedBlurb,
-      tags: textOnly.tags,
-    });
-
-    generated = {
-      ...textOnly,
-      country: countryTitle,
-      ingredients: sanitizedTopIngredients,
-      blurb: sanitizedBlurb,
-      imageUrl: imageResult.imageUrl,
-      imageGeneration: {
-        source: imageResult.source,
-        cost: imageResult.cost,
-        prompt: imageResult.prompt,
-        filename: imageResult.filename,
-      },
-    };
-    usedCandidate = cand;
-    break;
-  }
-
-  if (!generated) {
-    console.log("🚫 No acceptable candidate found this run. Skipping save.");
-    return;
-  }
-
-  // Double-check duplicates with the actual generated name
-  if (isDuplicate(generated.name || "", existing)) {
-    console.log(
-      `❌ Evaluator rejected: generated name duplicates existing dish/guess: ${generated.name}`
-    );
-    return;
-  }
-
-  // Evaluator: enforce constraints before saving
-  const countryTitle = titleCase(generated.country || "");
-  const blurb = generated.blurb || "";
-  const containsCountry =
-    countryTitle && new RegExp(`\\b${countryTitle}\\b`, "i").test(blurb);
-  const containsCountryWord = countryTitle
-    .toLowerCase()
-    .split(/[^a-z]+/)
-    .filter(Boolean)
-    .some((w) => new RegExp(`\\b${w}\\b`, "i").test(blurb));
-
-  if (containsCountry || containsCountryWord) {
-    console.log(
-      "❌ Evaluator rejected: blurb contains country name/adjective."
-    );
-    return;
-  }
-
-  if (!generated.ingredients || generated.ingredients.length !== 6) {
-    console.log("❌ Evaluator rejected: ingredients must be exactly 6.");
-    return;
-  }
-
-  // Country capitalization fix
-  (generated as any).country = countryTitle;
-
-  // Cost accounting: image is the main cost (~$0.04)
-  if (generated.imageGeneration?.cost) {
-    spent += generated.imageGeneration.cost;
-  } else {
-    spent += 0.04;
-  }
-
-  if (spent > maxSpend) {
-    console.log(
-      `⚠️ Budget exceeded (spent ~$${spent.toFixed(
-        2
-      )} > cap $${maxSpend.toFixed(2)}). Skipping save.`
-    );
-    return;
-  }
-
-  // Compute release date and save using SmartDishGenerator save logic
-  const nextRelease = await (async () => {
-    try {
-      return await getNextReleaseDate(supabase);
-    } catch {
-      return new Date().toISOString().split("T")[0];
-    }
-  })();
-
-  (generated as any).releaseDate = nextRelease;
-
-  // Compute coordinates based on country (same logic as SmartDishGenerator)
-  const coordsMap = getCountryCoordsMap();
-  const normCountry = (generated.country || "")
-    .toLowerCase()
-    .replace(/\s+/g, "");
-  let coords: { lat: number; lng: number } | null =
-    (coordsMap as any)[normCountry] || null;
-  if (!coords) {
-    for (const [countryKey, value] of Object.entries(coordsMap)) {
-      if (
-        countryKey.includes(normCountry) ||
-        normCountry.includes(countryKey)
-      ) {
-        coords = value as any;
-        break;
-      }
-    }
-  }
-  const coordinatesString = coords ? `(${coords.lng},${coords.lat})` : null;
-
-  // Manually perform DB insert (same as SmartDishGenerator.saveDishToDatabase)
-  const dishToInsert = {
-    name: generated.name,
-    acceptable_guesses: generated.acceptableGuesses,
-    country: generated.country,
-    image_url: generated.imageUrl || null,
-    ingredients: generated.ingredients,
-    blurb: generated.blurb,
-    fun_fact: generated.funFact || null,
-    protein_per_serving: generated.proteinPerServing || 0,
-    recipe: generated.recipe,
-    tags: generated.tags || [],
-    release_date: (generated as any).releaseDate,
-    coordinates: coordinatesString,
-    region: null,
-  };
-
-  console.log("\n💾 Saving to database...");
-  const { data, error } = await supabase
-    .from("dishes")
-    .insert([dishToInsert])
-    .select();
-  if (error) {
-    console.error("❌ Database error:", error.message);
-    return;
-  }
-  const savedDish = data?.[0];
-  console.log(`✅ Dish saved with ID: ${savedDish?.id}`);
-
-  // Generate tiles using original saved image (if available)
-  if (savedDish && savedDish.id && generated.imageUrl) {
-    console.log("\n🔲 Generating tiles for optimal performance...");
-    // Reuse SmartDishGenerator tile method via local helper (copy minimal logic)
-    const { default: Sharp } = await import("sharp");
-
-    try {
-      const imageResponse = await fetch(generated.imageUrl);
-      if (!imageResponse.ok)
-        throw new Error(`Failed to fetch image: ${generated.imageUrl}`);
-      const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
-
-      const image = (Sharp as any)(imageBuffer);
-      const metadata = await image.metadata();
-      if (!metadata.width || !metadata.height)
-        throw new Error("Invalid image metadata");
-
-      const targetAspectRatio = 3 / 2;
-      const currentAspectRatio = metadata.width / metadata.height;
-      let resizeWidth: number;
-      let resizeHeight: number;
-      if (currentAspectRatio > targetAspectRatio) {
-        resizeHeight = metadata.height;
-        resizeWidth = Math.round(resizeHeight * targetAspectRatio);
-      } else {
-        resizeWidth = metadata.width;
-        resizeHeight = Math.round(resizeWidth / targetAspectRatio);
+      if (!evalResult.accept) {
+        console.log("❌ Evaluator rejected:", evalResult.reasons.join("; "));
+        if (candidate.source === "backlog") removeFromBacklog(candidate.name);
+        continue;
       }
 
-      const cols = 3;
-      const rows = 2;
-      for (let tileIndex = 0; tileIndex < 6; tileIndex++) {
-        const row = Math.floor(tileIndex / cols);
-        const col = tileIndex % cols;
-        const tileWidth = Math.floor(resizeWidth / cols);
-        const tileHeight = Math.floor(resizeHeight / rows);
-        const left = col * tileWidth;
-        const top = row * tileHeight;
-        const actualWidth = col === cols - 1 ? resizeWidth - left : tileWidth;
-        const actualHeight = row === rows - 1 ? resizeHeight - top : tileHeight;
+      // Generate image
+      const imageResult = await imageService.generateDishImage({
+        name: textOnly.name,
+        ingredients: sanitizedTopIngredients,
+        country: countryTitle,
+        blurb: sanitizedBlurb,
+        tags: textOnly.tags,
+      });
 
-        const baseImage = image.resize(resizeWidth, resizeHeight, {
-          fit: "cover",
-          position: "center",
-        });
-        const regularTileBuffer = await baseImage
-          .clone()
-          .extract({ left, top, width: actualWidth, height: actualHeight })
-          .jpeg({ quality: 92, progressive: false })
-          .toBuffer();
+      spent += imageResult.cost || 0.04;
 
-        const blurredTileBuffer = await baseImage
-          .clone()
-          .extract({ left, top, width: actualWidth, height: actualHeight })
-          .blur(40)
-          .modulate({ brightness: 0.8, saturation: 0.6 })
-          .jpeg({ quality: 40 })
-          .toBuffer();
+      // Compute coordinates
+      const coordsMap = getCountryCoordsMap();
+      const normCountry = countryTitle.toLowerCase().replace(/\s+/g, "");
+      let coords: { lat: number; lng: number } | null =
+        (coordsMap as any)[normCountry] || null;
+      if (!coords) {
+        for (const [countryKey, value] of Object.entries(coordsMap)) {
+          if (
+            countryKey.includes(normCountry) ||
+            normCountry.includes(countryKey)
+          ) {
+            coords = value as any;
+            break;
+          }
+        }
+      }
+      const coordinatesString = coords ? `(${coords.lng},${coords.lat})` : null;
 
-        const prefix = (isBlurred: boolean) =>
-          isBlurred ? "blurred" : "regular";
-        const filenameRegular = `tiles/${savedDish.id}/${prefix(
-          false
-        )}-${tileIndex}.jpg`;
-        const filenameBlurred = `tiles/${savedDish.id}/${prefix(
-          true
-        )}-${tileIndex}.jpg`;
+      // Insert to database
+      const dishToInsert = {
+        name: textOnly.name,
+        acceptable_guesses: textOnly.acceptableGuesses,
+        country: countryTitle,
+        image_url: imageResult.imageUrl || null,
+        ingredients: sanitizedTopIngredients,
+        blurb: sanitizedBlurb,
+        fun_fact: textOnly.funFact || null,
+        protein_per_serving: textOnly.proteinPerServing || 0,
+        recipe: textOnly.recipe,
+        tags: textOnly.tags || [],
+        release_date: nextReleaseDate,
+        coordinates: coordinatesString,
+        region: null,
+      };
 
-        const { error: upErr1 } = await supabase.storage
-          .from("dish-tiles")
-          .upload(filenameRegular, regularTileBuffer, {
-            contentType: "image/jpeg",
-            upsert: true,
-          });
-        if (upErr1) throw new Error(upErr1.message);
+      console.log(`💾 Saving to database for ${nextReleaseDate}...`);
+      const { data, error } = await supabase
+        .from("dishes")
+        .insert([dishToInsert])
+        .select();
 
-        const { error: upErr2 } = await supabase.storage
-          .from("dish-tiles")
-          .upload(filenameBlurred, blurredTileBuffer, {
-            contentType: "image/jpeg",
-            upsert: true,
-          });
-        if (upErr2) throw new Error(upErr2.message);
+      if (error) {
+        console.error("❌ Database error:", error.message);
+        continue;
       }
 
-      console.log(`✅ Tiles generated successfully for ${generated.name}`);
+      const savedDish = data?.[0];
+      console.log(`✅ Dish saved with ID: ${savedDish?.id}`);
+
+      // Generate tiles
+      if (savedDish && savedDish.id && imageResult.imageUrl) {
+        console.log("🔲 Generating tiles...");
+        try {
+          await generateTiles(supabase, savedDish.id, imageResult.imageUrl);
+          console.log("✅ Tiles generated successfully");
+        } catch (e) {
+          console.error("❌ Failed to generate tiles:", e);
+        }
+      }
+
+      // Remove from backlog after success
+      if (candidate.source === "backlog") {
+        removeFromBacklog(candidate.name);
+      }
+
+      successCount++;
+
+      // Increment release date for next dish
+      const nextDate = new Date(nextReleaseDate);
+      nextDate.setDate(nextDate.getDate() + 1);
+      nextReleaseDate = nextDate.toISOString().split("T")[0];
+
     } catch (e) {
-      console.error("❌ Failed to generate tiles:", e);
+      console.error(`❌ Error generating ${candidate.name}:`, e);
+      if (candidate.source === "backlog") removeFromBacklog(candidate.name);
     }
   }
 
-  // Remove from backlog after success
-  if (usedCandidate && usedCandidate.source === "backlog") {
-    removeFromBacklog(usedCandidate.name);
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`🎉 Generation complete! ${successCount}/${candidatesToGenerate.length} dishes saved.`);
+  console.log(`💰 Total spent: $${spent.toFixed(2)}`);
+}
+
+// Tile generation helper
+async function generateTiles(
+  supabase: any,
+  dishId: number,
+  imageUrl: string
+): Promise<void> {
+  const { default: Sharp } = await import("sharp");
+
+  const imageResponse = await fetch(imageUrl);
+  if (!imageResponse.ok) throw new Error(`Failed to fetch image: ${imageUrl}`);
+  const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+
+  const image = (Sharp as any)(imageBuffer);
+  const metadata = await image.metadata();
+  if (!metadata.width || !metadata.height)
+    throw new Error("Invalid image metadata");
+
+  const targetAspectRatio = 3 / 2;
+  const currentAspectRatio = metadata.width / metadata.height;
+  let resizeWidth: number;
+  let resizeHeight: number;
+  if (currentAspectRatio > targetAspectRatio) {
+    resizeHeight = metadata.height;
+    resizeWidth = Math.round(resizeHeight * targetAspectRatio);
+  } else {
+    resizeWidth = metadata.width;
+    resizeHeight = Math.round(resizeWidth / targetAspectRatio);
   }
 
-  console.log("\n🎉 Daily generation completed successfully.");
+  const cols = 3;
+  const rows = 2;
+  for (let tileIndex = 0; tileIndex < 6; tileIndex++) {
+    const row = Math.floor(tileIndex / cols);
+    const col = tileIndex % cols;
+    const tileWidth = Math.floor(resizeWidth / cols);
+    const tileHeight = Math.floor(resizeHeight / rows);
+    const left = col * tileWidth;
+    const top = row * tileHeight;
+    const actualWidth = col === cols - 1 ? resizeWidth - left : tileWidth;
+    const actualHeight = row === rows - 1 ? resizeHeight - top : tileHeight;
+
+    const baseImage = image.resize(resizeWidth, resizeHeight, {
+      fit: "cover",
+      position: "center",
+    });
+    const regularTileBuffer = await baseImage
+      .clone()
+      .extract({ left, top, width: actualWidth, height: actualHeight })
+      .jpeg({ quality: 92, progressive: false })
+      .toBuffer();
+
+    const blurredTileBuffer = await baseImage
+      .clone()
+      .extract({ left, top, width: actualWidth, height: actualHeight })
+      .blur(40)
+      .modulate({ brightness: 0.8, saturation: 0.6 })
+      .jpeg({ quality: 40 })
+      .toBuffer();
+
+    const filenameRegular = `tiles/${dishId}/regular-${tileIndex}.jpg`;
+    const filenameBlurred = `tiles/${dishId}/blurred-${tileIndex}.jpg`;
+
+    const { error: upErr1 } = await supabase.storage
+      .from("dish-tiles")
+      .upload(filenameRegular, regularTileBuffer, {
+        contentType: "image/jpeg",
+        upsert: true,
+      });
+    if (upErr1) throw new Error(upErr1.message);
+
+    const { error: upErr2 } = await supabase.storage
+      .from("dish-tiles")
+      .upload(filenameBlurred, blurredTileBuffer, {
+        contentType: "image/jpeg",
+        upsert: true,
+      });
+    if (upErr2) throw new Error(upErr2.message);
+  }
 }
 
 main().catch((e) => {

--- a/src/data/continentGroups.ts
+++ b/src/data/continentGroups.ts
@@ -1,0 +1,316 @@
+/**
+ * Countries grouped by continent/region for dish generation.
+ * Enables O(1) lookup by region and sampling for AI prompts.
+ *
+ * Groups:
+ * - Europe: European countries
+ * - Asia: Asian countries (including Middle East, Caucasus)
+ * - Africa: African countries
+ * - Americas: North America, South America, Caribbean
+ * - Oceania: Australia, New Zealand, Pacific Islands
+ */
+
+export const CONTINENT_GROUPS: Record<string, string[]> = {
+  Europe: [
+    "Albania",
+    "Andorra",
+    "Austria",
+    "Belarus",
+    "Belgium",
+    "Bosnia and Herzegovina",
+    "Bulgaria",
+    "Croatia",
+    "Cyprus",
+    "Czechia",
+    "Denmark",
+    "Estonia",
+    "Finland",
+    "France",
+    "Germany",
+    "Greece",
+    "Hungary",
+    "Iceland",
+    "Ireland",
+    "Italy",
+    "Kosovo",
+    "Latvia",
+    "Liechtenstein",
+    "Lithuania",
+    "Luxembourg",
+    "Malta",
+    "Moldova",
+    "Monaco",
+    "Montenegro",
+    "Netherlands",
+    "North Macedonia",
+    "Norway",
+    "Poland",
+    "Portugal",
+    "Romania",
+    "Russia",
+    "San Marino",
+    "Serbia",
+    "Slovakia",
+    "Slovenia",
+    "Spain",
+    "Sweden",
+    "Switzerland",
+    "Ukraine",
+    "United Kingdom",
+    "Vatican City",
+  ],
+
+  Asia: [
+    "Afghanistan",
+    "Armenia",
+    "Azerbaijan",
+    "Bahrain",
+    "Bangladesh",
+    "Bhutan",
+    "Brunei",
+    "Cambodia",
+    "China",
+    "East Timor",
+    "Georgia",
+    "India",
+    "Indonesia",
+    "Iran",
+    "Iraq",
+    "Israel",
+    "Japan",
+    "Jordan",
+    "Kazakhstan",
+    "Kuwait",
+    "Kyrgyzstan",
+    "Laos",
+    "Lebanon",
+    "Malaysia",
+    "Maldives",
+    "Mongolia",
+    "Myanmar",
+    "Nepal",
+    "North Korea",
+    "Oman",
+    "Pakistan",
+    "Palestine",
+    "Philippines",
+    "Qatar",
+    "Saudi Arabia",
+    "Singapore",
+    "South Korea",
+    "Sri Lanka",
+    "Syria",
+    "Taiwan",
+    "Tajikistan",
+    "Thailand",
+    "Turkey",
+    "Turkmenistan",
+    "United Arab Emirates",
+    "Uzbekistan",
+    "Vietnam",
+    "Yemen",
+  ],
+
+  Africa: [
+    "Algeria",
+    "Angola",
+    "Benin",
+    "Botswana",
+    "Burkina Faso",
+    "Burundi",
+    "Cameroon",
+    "Cape Verde",
+    "Central African Republic",
+    "Chad",
+    "Comoros",
+    "Congo",
+    "Democratic Republic of the Congo",
+    "Djibouti",
+    "Egypt",
+    "Equatorial Guinea",
+    "Eritrea",
+    "Eswatini",
+    "Ethiopia",
+    "Gabon",
+    "Gambia",
+    "Ghana",
+    "Guinea",
+    "Guinea-Bissau",
+    "Kenya",
+    "Lesotho",
+    "Liberia",
+    "Libya",
+    "Madagascar",
+    "Malawi",
+    "Mali",
+    "Mauritania",
+    "Mauritius",
+    "Morocco",
+    "Mozambique",
+    "Namibia",
+    "Niger",
+    "Nigeria",
+    "Rwanda",
+    "Sao Tome and Principe",
+    "Senegal",
+    "Seychelles",
+    "Sierra Leone",
+    "Somalia",
+    "South Africa",
+    "South Sudan",
+    "Sudan",
+    "Tanzania",
+    "Togo",
+    "Tunisia",
+    "Uganda",
+    "Zambia",
+    "Zimbabwe",
+  ],
+
+  Americas: [
+    "Anguilla",
+    "Antigua and Barbuda",
+    "Argentina",
+    "Aruba",
+    "Bahamas",
+    "Barbados",
+    "Belize",
+    "Bermuda",
+    "Bolivia",
+    "Bonaire",
+    "Brazil",
+    "Canada",
+    "Cayman Islands",
+    "Chile",
+    "Colombia",
+    "Costa Rica",
+    "Cuba",
+    "Curaçao",
+    "Dominica",
+    "Dominican Republic",
+    "Ecuador",
+    "El Salvador",
+    "Grenada",
+    "Guatemala",
+    "Guyana",
+    "Haiti",
+    "Honduras",
+    "Jamaica",
+    "Mexico",
+    "Netherlands Antilles",
+    "Nicaragua",
+    "Panama",
+    "Paraguay",
+    "Peru",
+    "Saint Kitts and Nevis",
+    "Saint Lucia",
+    "Saint Vincent and the Grenadines",
+    "Suriname",
+    "Trinidad and Tobago",
+    "United States of America",
+    "Uruguay",
+    "Venezuela",
+  ],
+
+  Oceania: [
+    "American Samoa",
+    "Antarctica",
+    "Australia",
+    "Fiji",
+    "Kiribati",
+    "Marshall Islands",
+    "Micronesia",
+    "Nauru",
+    "New Zealand",
+    "Palau",
+    "Papua New Guinea",
+    "Samoa",
+    "Solomon Islands",
+    "Tonga",
+    "Tuvalu",
+    "Vanuatu",
+  ],
+};
+
+// Reverse lookup: country -> continent
+export const COUNTRY_TO_CONTINENT: Record<string, string> = {};
+for (const [continent, countries] of Object.entries(CONTINENT_GROUPS)) {
+  for (const country of countries) {
+    COUNTRY_TO_CONTINENT[country] = continent;
+  }
+}
+
+// All continent names
+export const CONTINENT_NAMES = Object.keys(CONTINENT_GROUPS);
+
+/**
+ * Sample N random countries from a specific continent
+ */
+export function sampleFromContinent(
+  continent: string,
+  count: number
+): string[] {
+  const countries = CONTINENT_GROUPS[continent];
+  if (!countries) return [];
+  const shuffled = [...countries].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+}
+
+/**
+ * Sample N countries from each continent with custom counts per region
+ * Default: 5 from Europe, Asia, Africa, Americas; 1 from Oceania = 21 total
+ */
+export function sampleFromAllContinents(options?: {
+  Europe?: number;
+  Asia?: number;
+  Africa?: number;
+  Americas?: number;
+  Oceania?: number;
+}): string[] {
+  const defaults = {
+    Europe: 5,
+    Asia: 5,
+    Africa: 5,
+    Americas: 5,
+    Oceania: 1,
+  };
+  const counts = { ...defaults, ...options };
+
+  const sampled: string[] = [];
+  for (const [continent, count] of Object.entries(counts)) {
+    sampled.push(...sampleFromContinent(continent, count));
+  }
+  return sampled;
+}
+
+// Major continents (excluding Oceania for weighted sampling)
+export const MAJOR_CONTINENTS = ["Europe", "Asia", "Africa", "Americas"];
+
+/**
+ * Sample countries with weighted distribution:
+ * - Pick 1 random major continent → 5 countries
+ * - Other 3 major continents → 3 countries each = 9 countries
+ * - Oceania → 1 country
+ * - Total: 15 countries
+ */
+export function sampleCountriesWeighted(): string[] {
+  // Shuffle major continents and pick one to be the "featured" continent
+  const shuffledMajor = [...MAJOR_CONTINENTS].sort(() => Math.random() - 0.5);
+  const featuredContinent = shuffledMajor[0];
+  const otherMajorContinents = shuffledMajor.slice(1);
+
+  const sampled: string[] = [];
+
+  // 5 countries from featured continent
+  sampled.push(...sampleFromContinent(featuredContinent, 5));
+
+  // 3 countries from each of the other 3 major continents
+  for (const continent of otherMajorContinents) {
+    sampled.push(...sampleFromContinent(continent, 3));
+  }
+
+  // 1 country from Oceania
+  sampled.push(...sampleFromContinent("Oceania", 1));
+
+  return sampled;
+}


### PR DESCRIPTION
## Summary

- **Weighted country sampling**: Samples 15 countries (5 from a random major continent, 3 from each of the other 3 major continents, 1 from Oceania) instead of all 205 countries
- **Smarter blocked dishes list**: Builds targeted list from 3 queries (future dishes, past dishes from sampled countries, recent 60 days) instead of 400+ normalized names
- **Human-readable names**: Uses "Beef Bulgogi" format in prompts instead of "beefbulgogi" so AI can actually recognize duplicates
- **Multi-dish generation**: Fills buffer faster by generating multiple dishes per run when needed
- **Repeatable dishes**: Allows old dishes to appear again after 60+ days if not from sampled countries

## Problem

The daily generation script was failing because:
1. AI received 400 normalized dish names in a comma-blob format (hard to parse)
2. AI received 205 countries (too many to choose from effectively)
3. AI kept suggesting duplicates that already exist in the 8-month history
4. Buffer depleted to 0 → game failed for users

## Test plan

- [ ] Set up environment secrets (OPENAI_API_KEY, SUPABASE_URL, SUPABASE_SERVICE_KEY)
- [ ] Run `npx tsx scripts/daily-generate.ts`
- [ ] Verify dishes are generated without duplicate rejections
- [ ] Verify buffer fills up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)