### PR TITLE
Feature/game experience improvements

### DIFF
--- a/.github/workflows/daily-generate.yml
+++ b/.github/workflows/daily-generate.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           cat > .env.local << 'EOF'
           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
           NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           DAILY_COST_CAP_USD=${{ secrets.DAILY_COST_CAP_USD }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# git worktrees
+.worktrees
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/docs/superpowers/plans/2026-05-22-game-experience-improvements.md
+++ b/docs/superpowers/plans/2026-05-22-game-experience-improvements.md
@@ -1,0 +1,1616 @@
+# Game Experience Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the four sections of improvements defined in `docs/superpowers/specs/2026-05-22-game-experience-improvements-design.md` — small UX wins, broader dish acceptance, a cuisine-region progressive hint, and an image-generation upgrade to Imagen 4 Ultra.
+
+**Architecture:** Each section is independently shippable. Section 1 is pure UI tweaks on existing components. Section 2 edits the AI prompt + adds one runtime helper. Section 3 adds one new data file and one new component. Section 4 introduces an `ImageGenerator` adapter so DALL-E 3 and the new Imagen 4 Ultra path can coexist behind a stable interface. Each task ends with a commit; each section corresponds to a natural PR boundary.
+
+**Tech Stack:** Next.js 15 App Router, React 19, Zustand, Radix UI, framer-motion, Tailwind, OpenAI SDK (for text gen), `@google/genai` (new — for Imagen 4 image gen), Supabase (storage + db), Sharp (tile slicing).
+
+**Testing approach:** This codebase has no test framework today. To respect that and ship velocity, this plan uses **manual play-through verification** for UI changes (per the spec's Testing section) and **inline `tsx` script invocations** for verifying pure-function helpers. No vitest/jest installation.
+
+---
+
+## File Structure
+
+**Created:**
+- `src/data/cuisineRegions.ts` — country → region map for Section 3.
+- `src/components/RegionHintChip.tsx` — progressive hint chip for Section 3.
+- `src/services/imageGenerators/types.ts` — `ImageGenerator` interface for Section 4.
+- `src/services/imageGenerators/openaiDallE3.ts` — DALL-E 3 implementation (extracted from current code, kept as fallback).
+- `src/services/imageGenerators/googleImagen4Ultra.ts` — new Imagen 4 Ultra implementation for Section 4.
+- `src/services/imageGenerators/index.ts` — barrel + factory.
+- `scripts/expand-acceptable-guesses.ts` — one-time backfill for Section 2.
+- `scripts/verify-fuzzy-match.ts` — throwaway verification harness (deleted after use).
+
+**Modified:**
+- `src/components/ResultModal.tsx` — Radix Dialog (Section 1.1).
+- `src/components/GameSummary.tsx` or `src/app/play/ProteinPhase.tsx` — "View Results" re-open button (Section 1.1).
+- `src/components/inputs/TextInput.tsx` — desktop-only autofocus (Section 1.2).
+- `src/components/inputs/GiveUpButton.tsx` — outline + label visual (Section 1.3).
+- `src/components/GuessInput.tsx` — remove secondary "give up and see results" link (Section 1.3).
+- `src/components/GameHeader.tsx` — streak chip next to Statistics (Section 1.4).
+- `src/components/ArchiveDatePicker.tsx` — 30 → 90 day range (Section 1.5).
+- `src/services/aiService.ts` — bump `acceptableGuesses` target to 6–10, validation update (Section 2.1).
+- `src/utils/gameHelpers.ts` — add `getStrongFuzzyMatch` helper (Section 2.2).
+- `src/app/play/DishPhase.tsx` — wire `getStrongFuzzyMatch` into correctness check (Section 2.2).
+- `src/components/GuessFeedback.tsx` — render `RegionHintChip` below ingredient chips (Section 3.3).
+- `src/services/dishImageService.ts` — use `ImageGenerator` adapter + new cinematographic prompt (Section 4).
+- `scripts/daily-generate.ts` — adapt `generateTiles` to skip resize when source is already 3:2 (Section 4.3).
+- `.github/workflows/daily-generate.yml` — add `GEMINI_API_KEY` to env file (Section 4).
+
+**Deleted (after one-time use):**
+- `scripts/expand-acceptable-guesses.ts`
+- `scripts/verify-fuzzy-match.ts`
+
+---
+
+# Section 1 — Small UX wins
+
+## Task 1.1: Convert ResultModal to Radix Dialog
+
+**Files:**
+- Modify: `src/components/ResultModal.tsx`
+
+- [ ] **Step 1: Import Dialog primitives**
+
+At the top of `src/components/ResultModal.tsx`, add:
+
+```tsx
+import {
+  Dialog,
+  DialogContent,
+} from "@/components/ui/dialog";
+```
+
+- [ ] **Step 2: Replace the outer `<div className="fixed inset-0 ...">` wrapper with `Dialog` + `DialogContent`**
+
+Replace the JSX return block starting at the current `<div className="fixed inset-0 bg-black bg-opacity-50 ...">` with:
+
+```tsx
+return (
+  <Dialog
+    open={modalVisible}
+    onOpenChange={(open) => {
+      if (!open) {
+        toggleModal(false);
+        posthog.capture("toggle_recipe_modal", { opened: false });
+      }
+    }}
+  >
+    <DialogContent className="max-w-md w-full max-h-[90vh] overflow-y-auto gap-4 flex flex-col p-4 sm:p-6">
+      <div className="flex flex-col gap-1">
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl sm:text-2xl font-bold">🎉 You did it!</h2>
+        </div>
+        {streak >= 1 && (
+          <div className="text-orange-500 font-semibold text-sm mt-2 animate-streak-pop">
+            🔥 You&apos;re on a {streak}-day streak!
+          </div>
+        )}
+      </div>
+      {/* …rest of the existing modal body unchanged… */}
+    </DialogContent>
+  </Dialog>
+);
+```
+
+Notes:
+- Delete the existing inline `<button onClick={() => toggleModal(false)} ...>✕</button>` — Radix `DialogContent` renders its own close button by default.
+- Keep all internal content (image, dish info, `GameSummary`, `LeaderboardCard`, `ArchiveStatus`, action row, recipe panel, footer) unchanged.
+- Delete the early-return guard `if (gamePhase !== "complete" || !currentDish || !modalVisible) return null;` and replace it with a guard that returns `null` only when `gamePhase !== "complete" || !currentDish`. The `open={modalVisible}` binding handles visibility.
+
+- [ ] **Step 3: Manually verify modal dismiss paths**
+
+Run dev server (`npm run dev`), complete a game (use a test dish or play through), and confirm:
+- Pressing `Esc` closes the modal.
+- Clicking the dark backdrop area closes the modal.
+- The X close button (rendered by Radix) closes the modal.
+- The PostHog `toggle_recipe_modal` event fires with `{ opened: false }` on close.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ResultModal.tsx
+git commit -m "feat(modal): dismiss results modal with Esc and outside-click via Radix Dialog"
+```
+
+## Task 1.2: Add "View Results" re-open affordance after modal close
+
+**Files:**
+- Modify: `src/app/play/ProteinPhase.tsx`
+
+- [ ] **Step 1: Read the current file to confirm where the "complete" view renders**
+
+Look at `src/app/play/ProteinPhase.tsx` — identify where the post-completion content is rendered (after a correct protein guess). The "View Results" button needs to appear there when `gamePhase === "complete"` and `modalVisible === false`.
+
+- [ ] **Step 2: Add the button**
+
+In `ProteinPhase.tsx`, at the bottom of the JSX returned when the phase is complete, add:
+
+```tsx
+{gamePhase === "complete" && !modalVisible && (
+  <div className="flex justify-center mt-4">
+    <Button
+      variant="cta"
+      onClick={() => toggleModal(true)}
+    >
+      📋 View Results
+    </Button>
+  </div>
+)}
+```
+
+Add the corresponding selectors to the existing `useGameStore` calls in the file:
+
+```ts
+const gamePhase = useGameStore((state) => state.gamePhase);
+const modalVisible = useGameStore((state) => state.modalVisible);
+const toggleModal = useGameStore((state) => state.toggleModal);
+```
+
+Add the import: `import { Button } from "@/components/ui/button";` if not already present.
+
+- [ ] **Step 3: Manually verify**
+
+Complete a game, close the modal (Esc), confirm the "View Results" button appears at the bottom of the protein phase view. Click it — modal re-opens with the same data. No score re-submission (check network panel for absence of duplicate `/api/leaderboard` POSTs).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/play/ProteinPhase.tsx
+git commit -m "feat(modal): persist 'View Results' button so a dismissed modal can be reopened"
+```
+
+## Task 1.3: Desktop-only autofocus on text input
+
+**Files:**
+- Modify: `src/components/inputs/TextInput.tsx`
+
+- [ ] **Step 1: Add the ref, the desktop detection, and the autofocus effect**
+
+In `src/components/inputs/TextInput.tsx`, add at the top of the component body (after the `useState`/`useGameStore` calls):
+
+```tsx
+const inputRef = useRef<HTMLInputElement>(null);
+
+useEffect(() => {
+  if (typeof window === "undefined") return;
+  const isDesktop = window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+  if (isDesktop && !isComplete && !disabled) {
+    inputRef.current?.focus();
+  }
+}, [isComplete, disabled]);
+```
+
+Add the corresponding React imports:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+```
+
+(Replace whatever the existing `import { useState }` line is.)
+
+- [ ] **Step 2: Wire the ref onto the Input element**
+
+Find the `<Input ... />` usage near the bottom of the file (around line 134 in the current code) and add `ref={inputRef}`:
+
+```tsx
+<Input
+  ref={inputRef}
+  type="text"
+  value={value}
+  /* …other existing props… */
+/>
+```
+
+- [ ] **Step 3: Verify `Input` forwards refs**
+
+Read `src/components/ui/input.tsx`. If it doesn't forward refs to the underlying DOM input, wrap it with `React.forwardRef`:
+
+```tsx
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => (
+    <input ref={ref} className={cn("…existing classes…", className)} {...props} />
+  )
+);
+Input.displayName = "Input";
+```
+
+(Keep whatever existing classes/styles are on the original component — copy them into the `cn(...)` call. Don't remove styling.)
+
+- [ ] **Step 4: Manually verify on desktop and mobile**
+
+Desktop browser: load `/play`, confirm the dish-phase input is focused on mount (cursor is in the input, you can immediately start typing). After advancing to the country phase, confirm the country input is focused on mount.
+
+Mobile browser / responsive devtools toggle: load `/play`, confirm the input is NOT focused and the soft keyboard does NOT pop.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/inputs/TextInput.tsx src/components/ui/input.tsx
+git commit -m "feat(input): autofocus text inputs on desktop only on phase entry"
+```
+
+## Task 1.4: Replace cryptic flag icon with outline-style "Give up" button
+
+**Files:**
+- Modify: `src/components/inputs/GiveUpButton.tsx`
+- Modify: `src/components/GuessInput.tsx`
+
+- [ ] **Step 1: Rewrite GiveUpButton with icon + label**
+
+Replace the body of `src/components/inputs/GiveUpButton.tsx` from the JSX return downward:
+
+```tsx
+return (
+  <>
+    <Dialog open={giveUpOpen} onOpenChange={setGiveUpOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Are you sure you want to give up?</DialogTitle>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="default" onClick={() => setGiveUpOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="outline" onClick={handleGiveUp}>
+            Ok
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => setGiveUpOpen(true)}
+      className="text-xs sm:text-sm whitespace-nowrap"
+    >
+      🏳️ Give up
+    </Button>
+  </>
+);
+```
+
+Delete the `import Image from "next/image";` line — it's no longer used. The `/images/give-up.png` asset can stay on disk (don't delete it; other branches or future flows may want it).
+
+- [ ] **Step 2: Remove the secondary "Give up and see results" link from GuessInput**
+
+In `src/components/GuessInput.tsx`, locate the block (around lines 165–167 and 219–230):
+
+```tsx
+const shouldShowGiveUp = isProteinPhase
+  ? previousProteinGuesses.length >= 3
+  : false;
+```
+
+and the JSX block that uses it:
+
+```tsx
+{shouldShowGiveUp && !isComplete && (
+  <div className="absolute top-full left-0 right-0 text-center mt-2">
+    <Button onClick={handleGiveUp} variant="outline" size="sm" className="text-xs">
+      Give up and see results
+    </Button>
+  </div>
+)}
+```
+
+Delete both blocks. The primary `<GiveUpButton />` is now the only give-up surface.
+
+- [ ] **Step 3: Manually verify across all three phases**
+
+Load a game. In each of dish, country, and protein phase: the "🏳️ Give up" button appears next to the input from the very first interaction (no minimum-guess gating). Clicking it opens the confirm dialog. Clicking "Ok" advances the phase as before.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/inputs/GiveUpButton.tsx src/components/GuessInput.tsx
+git commit -m "feat(give-up): replace flag icon with labelled outline button, drop redundant secondary link"
+```
+
+## Task 1.5: Streak chip in header
+
+**Files:**
+- Modify: `src/components/GameHeader.tsx`
+
+- [ ] **Step 1: Pull streak from the store and render a chip**
+
+In `src/components/GameHeader.tsx`, extend the existing `useGameStore` destructure to include `streak`:
+
+```tsx
+const { isPlayingArchive, archiveDate, exitArchiveMode, streak } = useGameStore();
+```
+
+Inside the right-side `<div className="flex items-center gap-3">` (around line 53), **before** the `showStatisticsButton` block, add:
+
+```tsx
+{streak >= 1 && !isPlayingArchive && (
+  <Link href="/statistics">
+    <div
+      className="flex items-center gap-1 px-2 py-1 bg-orange-100 hover:bg-orange-200 text-orange-700 rounded-md text-sm font-semibold transition-colors"
+      title={`${streak}-day streak`}
+    >
+      <span>🔥</span>
+      <span>{streak}</span>
+    </div>
+  </Link>
+)}
+```
+
+- [ ] **Step 2: Manually verify**
+
+If you have a streak of 0 today, simulate one in dev: open browser devtools → Application → Local Storage → set the streak key to a value ≥1 (look in `src/utils/streak.ts` for the exact key), reload `/play`. Confirm the 🔥 chip renders next to the Statistics button. Click it — should route to `/statistics`. In archive mode the chip should not render (header already filters statistics in archive mode; the same condition guards the chip).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/GameHeader.tsx
+git commit -m "feat(header): show streak chip next to Statistics when streak >= 1"
+```
+
+## Task 1.6: Expand archive range from 30 to 90 days
+
+**Files:**
+- Modify: `src/components/ArchiveDatePicker.tsx`
+
+- [ ] **Step 1: Bump the constant**
+
+In `src/components/ArchiveDatePicker.tsx`, replace lines 34–36:
+
+```tsx
+const earliestDate = new Date();
+earliestDate.setDate(today.getDate() - 30);
+const earliestDateString = earliestDate.toISOString().split("T")[0];
+```
+
+with:
+
+```tsx
+const ARCHIVE_DAYS_BACK = 90;
+const earliestDate = new Date();
+earliestDate.setDate(today.getDate() - ARCHIVE_DAYS_BACK);
+const earliestDateString = earliestDate.toISOString().split("T")[0];
+```
+
+Also update the dialog description text in the same file (~line 170):
+
+```tsx
+<DialogDescription>
+  Select a date to play a previous game. You can only access games
+  from the last 90 days.
+</DialogDescription>
+```
+
+- [ ] **Step 2: Verify the archive API does not enforce its own 30-day cap**
+
+Read `src/pages/api/dishes.ts` and `src/pages/api/archive-unlock.ts`. Search for the literal `30` and for any date arithmetic. If either file enforces a 30-day window on the server side, change that constant to `90` too. If neither does, no further changes are needed.
+
+- [ ] **Step 3: Manually verify**
+
+Open the archive date picker, navigate back through months — confirm dates from up to 90 days ago are selectable (previously the past 31st day onward was greyed out). Pick a date 60 days back and confirm the dish loads.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ArchiveDatePicker.tsx src/pages/api/dishes.ts src/pages/api/archive-unlock.ts
+git commit -m "feat(archive): expand playable archive range from 30 to 90 days"
+```
+
+(Only stage the API files if Step 2 required edits.)
+
+---
+
+# Section 2 — Widen dish acceptance
+
+## Task 2.1: Broaden AI-generated acceptable guesses (6–10 variations)
+
+**Files:**
+- Modify: `src/services/aiService.ts`
+
+- [ ] **Step 1: Update the prompt**
+
+In `src/services/aiService.ts`, find the requirements block (line ~145):
+
+```ts
+2. acceptableGuesses: 2-4 smart variations/alternative names people might use for "${dishName}"
+```
+
+Replace with:
+
+```ts
+2. acceptableGuesses: 6-10 smart variations and alternative names people might use for "${dishName}". Include:
+   - Shortened or common-misname forms (e.g. "piri piri" for "Piri-piri Chicken").
+   - English vs. native-language names where both are commonly used.
+   - Singular and plural forms.
+   - Common alternate spellings and regional variants.
+   All entries lowercase, no duplicates.
+```
+
+- [ ] **Step 2: Update validation**
+
+In the same file, find `validateDishData` (line ~286) and change:
+
+```ts
+Array.isArray(dishData.acceptableGuesses) &&
+dishData.acceptableGuesses.length >= 1 &&
+```
+
+to:
+
+```ts
+Array.isArray(dishData.acceptableGuesses) &&
+dishData.acceptableGuesses.length >= 6 &&
+```
+
+- [ ] **Step 3: Manually generate one dish end-to-end to verify**
+
+Run a single-dish smoke test:
+
+```bash
+npm run smart-generate -- --name "Margherita Pizza"
+```
+
+(If `smart-generate` doesn't accept a name flag in the current implementation, use whichever one-off generation script the repo provides — e.g. `tsx scripts/test-single-dish.ts`. Skim that script first to confirm the invocation.)
+
+Inspect the output JSON — confirm `acceptableGuesses` contains at least 6 entries covering the variation types above.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/aiService.ts
+git commit -m "feat(dish-gen): generate 6-10 acceptable guesses per dish with explicit variation guidance"
+```
+
+## Task 2.2: Add `getStrongFuzzyMatch` helper
+
+**Files:**
+- Modify: `src/utils/gameHelpers.ts`
+
+- [ ] **Step 1: Append the helper to gameHelpers.ts**
+
+At the end of `src/utils/gameHelpers.ts`, after the existing `getClosestGuess` function, add:
+
+```ts
+/**
+ * Returns the canonical match string when the input is a high-confidence match
+ * for one of the options. Used to auto-accept near-perfect fuzzy matches
+ * without showing a "did you mean?" prompt. Returns null when confidence is
+ * not high enough to auto-accept.
+ */
+export function getStrongFuzzyMatch(
+  input: string,
+  options: string[]
+): string | null {
+  const normalizedInput = input.toLowerCase().trim();
+  if (normalizedInput.length < 3) return null;
+
+  // Exact-substring containment: input is a substantial portion of an option,
+  // or an option is a substantial portion of input.
+  for (const option of options) {
+    const normalizedOption = option.toLowerCase();
+    if (
+      normalizedOption.includes(normalizedInput) &&
+      normalizedInput.length / normalizedOption.length >= 0.5
+    ) {
+      return option;
+    }
+    if (
+      normalizedInput.includes(normalizedOption) &&
+      normalizedOption.length / normalizedInput.length >= 0.5
+    ) {
+      return option;
+    }
+  }
+
+  // Very high-confidence fuzzy match (Fuse score <= 0.15 is essentially a typo).
+  const fuse = new Fuse(options, {
+    threshold: 0.4,
+    includeScore: true,
+    ignoreLocation: false,
+    distance: 10,
+  });
+  const results = fuse.search(normalizedInput);
+  if (results.length === 0) return null;
+
+  const best = results[0];
+  if ((best.score ?? 1) <= 0.15) {
+    return best.item;
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 2: Write a throwaway verification script**
+
+Create `scripts/verify-fuzzy-match.ts`:
+
+```ts
+import { getStrongFuzzyMatch } from "../src/utils/gameHelpers";
+
+const dishOptions = ["piri-piri chicken", "peri-peri chicken", "piri piri"];
+
+const cases: Array<[string, string | null]> = [
+  ["piri piri", "piri piri"],          // exact match to one of the options
+  ["piri-piri", "piri-piri chicken"],  // strong substring
+  ["pirir piri chicken", "piri-piri chicken"], // typo, very close
+  ["adasd", null],                     // nonsense
+  ["chicken", null],                   // partial too generic — substring ratio is too low
+  ["xx", null],                        // too short
+];
+
+let failed = 0;
+for (const [input, expected] of cases) {
+  const got = getStrongFuzzyMatch(input, dishOptions);
+  const ok = got === expected;
+  console.log(`${ok ? "✅" : "❌"}  input=${JSON.stringify(input)}  expected=${JSON.stringify(expected)}  got=${JSON.stringify(got)}`);
+  if (!ok) failed++;
+}
+process.exit(failed === 0 ? 0 : 1);
+```
+
+- [ ] **Step 3: Run the verification script and confirm all pass**
+
+```bash
+npx tsx scripts/verify-fuzzy-match.ts
+```
+
+Expected: six `✅` lines, exit code 0. If any fail, adjust thresholds in `getStrongFuzzyMatch` until they pass without breaking the others.
+
+- [ ] **Step 4: Delete the throwaway script**
+
+```bash
+rm scripts/verify-fuzzy-match.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/gameHelpers.ts
+git commit -m "feat(guess): add getStrongFuzzyMatch for high-confidence dish-name acceptance"
+```
+
+## Task 2.3: Wire `getStrongFuzzyMatch` into the dish phase
+
+**Files:**
+- Modify: `src/app/play/DishPhase.tsx`
+
+- [ ] **Step 1: Update the import and the correctness check**
+
+At the top of `src/app/play/DishPhase.tsx`, change:
+
+```tsx
+import { useGameStore } from "@/store";
+```
+
+to add the helper import:
+
+```tsx
+import { useGameStore } from "@/store";
+import { getStrongFuzzyMatch } from "@/utils/gameHelpers";
+```
+
+Replace the `handleGuess` function body (around line 35):
+
+```tsx
+const handleGuess = (guess: string) => {
+  const normalized = guess.toLowerCase().trim();
+  const acceptable = currentDish?.acceptableGuesses ?? [];
+
+  const exactMatch = acceptable.includes(normalized);
+  const fuzzyMatch = exactMatch ? null : getStrongFuzzyMatch(normalized, acceptable);
+
+  const isCorrect = exactMatch || !!fuzzyMatch;
+  const guessToRecord = fuzzyMatch ?? guess;
+
+  posthog.capture("guess_dish", {
+    guess,
+    correct: isCorrect,
+    fuzzy_match: !!fuzzyMatch,
+  });
+
+  guessDish(guessToRecord);
+};
+```
+
+- [ ] **Step 2: Manually verify against a live dish**
+
+Run dev server and play through a dish whose `acceptableGuesses` includes a known short form. Try:
+- The canonical name — should be accepted (as before).
+- The short form ("piri piri" for "Piri-piri Chicken") — should be accepted via fuzzy match. Confirm via devtools that PostHog event shows `fuzzy_match: true`.
+- A typo of the canonical name — should be accepted (or fall through to the existing "did you mean?" toast if the typo is too far off).
+- Random nonsense — should be a normal wrong guess, no fuzzy match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/play/DishPhase.tsx
+git commit -m "feat(dish-phase): auto-accept high-confidence fuzzy matches and record canonical form"
+```
+
+## Task 2.4: One-time backfill script for existing dishes
+
+**Files:**
+- Create: `scripts/expand-acceptable-guesses.ts`
+
+- [ ] **Step 1: Create the script**
+
+Create `scripts/expand-acceptable-guesses.ts`:
+
+```ts
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { createClient } from "@supabase/supabase-js";
+import OpenAI from "openai";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+interface DishRow {
+  id: number;
+  name: string;
+  acceptable_guesses: string[] | null;
+}
+
+async function expandOne(name: string, existing: string[]): Promise<string[]> {
+  const prompt = `Given the dish "${name}" and the current list of accepted player guesses:
+${JSON.stringify(existing)}
+
+Expand this list to 6-10 entries total. Add entries covering:
+- Shortened/common-misname forms (e.g. "piri piri" for "Piri-piri Chicken").
+- English vs. native-language names where both are commonly used.
+- Singular and plural forms.
+- Common alternate spellings and regional variants.
+
+Return ONLY a JSON array of lowercase strings. No duplicates. Preserve the existing entries.`;
+
+  const res = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0.3,
+    max_tokens: 400,
+  });
+
+  const content = res.choices[0]?.message?.content?.trim() ?? "";
+  const cleaned = content.replace(/^```json\s*/, "").replace(/```\s*$/, "");
+  const parsed = JSON.parse(cleaned) as string[];
+
+  const merged = Array.from(new Set([...existing.map((s) => s.toLowerCase()), ...parsed.map((s) => s.toLowerCase())]));
+  return merged;
+}
+
+async function main() {
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const { data, error } = await supabase
+    .from("dishes")
+    .select("id,name,acceptable_guesses");
+  if (error) throw error;
+
+  const rows = (data ?? []) as DishRow[];
+  let updated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const current = row.acceptable_guesses ?? [];
+    if (current.length >= 6) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      console.log(`🔄 Expanding ${row.name} (currently ${current.length} entries)…`);
+      const expanded = await expandOne(row.name, current);
+
+      const { error: upErr } = await supabase
+        .from("dishes")
+        .update({ acceptable_guesses: expanded })
+        .eq("id", row.id);
+      if (upErr) throw upErr;
+
+      console.log(`  ✅ Now ${expanded.length} entries.`);
+      updated++;
+    } catch (e) {
+      console.error(`  ❌ Failed for ${row.name}:`, e);
+      failed++;
+    }
+  }
+
+  console.log(`\nDone. Updated: ${updated}, Skipped (already >= 6): ${skipped}, Failed: ${failed}`);
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Run a dry-run on the first few dishes locally to sanity-check the output**
+
+Temporarily add `if (updated >= 3) break;` after the `updated++` line, run once:
+
+```bash
+npx tsx scripts/expand-acceptable-guesses.ts
+```
+
+Inspect the database (Supabase studio or a `select id,name,acceptable_guesses` query) and confirm three dishes now have ≥6 entries with sensible variation. Remove the early-break.
+
+- [ ] **Step 3: Run the full backfill**
+
+```bash
+npx tsx scripts/expand-acceptable-guesses.ts
+```
+
+Expect: every dish that previously had <6 entries is now updated. The script is idempotent — re-running it skips dishes already at ≥6.
+
+- [ ] **Step 4: Delete the script and commit**
+
+```bash
+rm scripts/expand-acceptable-guesses.ts
+git add scripts/expand-acceptable-guesses.ts
+git commit -m "chore(dishes): one-time backfill of acceptable guesses (script removed after use)"
+```
+
+(`git add` will stage the deletion. The DB changes were applied by Step 3 and don't need staging.)
+
+---
+
+# Section 3 — Cuisine-region progressive hint
+
+## Task 3.1: Build the cuisine-region data map
+
+**Files:**
+- Create: `src/data/cuisineRegions.ts`
+
+- [ ] **Step 1: Get the list of distinct countries currently in the database**
+
+Run from the project root:
+
+```bash
+npx tsx -e "
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+sb.from('dishes').select('country').then(({data}) => {
+  const uniq = [...new Set((data ?? []).map((r: any) => r.country))].sort();
+  console.log(JSON.stringify(uniq, null, 2));
+});
+"
+```
+
+Save the printed array — it's the input to Step 2.
+
+- [ ] **Step 2: Create the data file**
+
+Create `src/data/cuisineRegions.ts` populated with one entry per country printed in Step 1. Example shape (extend to cover every country):
+
+```ts
+/**
+ * Cuisine-region map keyed by the `country` field on dishes.
+ * Used by the dish-phase progressive hint chip.
+ * Region labels are intentionally broad — the goal is to nudge the player
+ * toward the right corner of the world, not narrow the answer further.
+ */
+export const CUISINE_REGIONS: Record<string, string> = {
+  Portugal: "Iberian / Southern Europe",
+  Spain: "Iberian / Southern Europe",
+  Italy: "Mediterranean Europe",
+  France: "Western Europe",
+  Greece: "Mediterranean Europe",
+  Turkey: "Anatolia / Eastern Mediterranean",
+  Lebanon: "Levant / Middle East",
+  Israel: "Levant / Middle East",
+  Morocco: "North Africa / Maghreb",
+  India: "South Asia",
+  Pakistan: "South Asia",
+  Thailand: "Southeast Asia",
+  Vietnam: "Southeast Asia",
+  Indonesia: "Southeast Asia",
+  Japan: "East Asia",
+  China: "East Asia",
+  Korea: "East Asia",
+  // …extend with every country from Step 1…
+  Mexico: "Latin America",
+  Peru: "Latin America",
+  Brazil: "Latin America",
+  USA: "North America",
+};
+
+export function getCuisineRegion(country: string): string | null {
+  return CUISINE_REGIONS[country] ?? null;
+}
+```
+
+Every country from Step 1 must appear as a key. If you genuinely can't categorize one, omit it — `getCuisineRegion` returns `null` and the chip won't render for that dish.
+
+- [ ] **Step 3: Quick coverage check**
+
+Run:
+
+```bash
+npx tsx -e "
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+import { createClient } from '@supabase/supabase-js';
+import { getCuisineRegion } from './src/data/cuisineRegions';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+sb.from('dishes').select('country').then(({data}) => {
+  const missing = [...new Set((data ?? []).map((r: any) => r.country))].filter(c => !getCuisineRegion(c));
+  console.log(missing.length ? 'Missing regions for:' : 'All countries mapped ✅');
+  if (missing.length) console.log(missing);
+});
+"
+```
+
+Expected: `All countries mapped ✅`. If any countries are missing, decide per-country whether to add a mapping or leave it unmapped (which gracefully skips the hint for that dish).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/data/cuisineRegions.ts
+git commit -m "feat(hints): add cuisine-region map for dish-phase progressive hint"
+```
+
+## Task 3.2: Build `RegionHintChip` component
+
+**Files:**
+- Create: `src/components/RegionHintChip.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/RegionHintChip.tsx`:
+
+```tsx
+"use client";
+
+import { motion } from "framer-motion";
+import React from "react";
+
+interface RegionHintChipProps {
+  region: string;
+}
+
+export const RegionHintChip: React.FC<RegionHintChipProps> = ({ region }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="relative inline-flex items-center gap-2 self-start mt-2 px-3 py-1.5 rounded-full border border-indigo-300 bg-indigo-50 text-indigo-800 text-sm font-medium overflow-hidden animate-hint-glow"
+    >
+      <span aria-hidden>💡</span>
+      <span>
+        <span className="opacity-70 mr-1">Hint:</span>
+        {region}
+      </span>
+      <span className="absolute inset-0 pointer-events-none animate-hint-shimmer" />
+    </motion.div>
+  );
+};
+```
+
+- [ ] **Step 2: Add the keyframes to globals.css**
+
+Open `src/app/globals.css` and append:
+
+```css
+@keyframes hint-glow {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.0); }
+  50%      { box-shadow: 0 0 16px 2px rgba(99, 102, 241, 0.35); }
+}
+.animate-hint-glow {
+  animation: hint-glow 2.4s ease-in-out infinite;
+}
+
+@keyframes hint-shimmer {
+  0%   { transform: translateX(-100%); opacity: 0; }
+  10%  { opacity: 0.6; }
+  60%  { opacity: 0.6; }
+  100% { transform: translateX(100%); opacity: 0; }
+}
+.animate-hint-shimmer {
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.55) 50%,
+    transparent 70%
+  );
+  animation: hint-shimmer 1.2s ease-out 0.1s 1 forwards;
+}
+```
+
+(The shimmer runs once on mount; the glow loops gently to keep marking it as a clue without becoming distracting.)
+
+- [ ] **Step 3: Visually verify the component in isolation**
+
+Temporarily add `<RegionHintChip region="Iberian / Southern Europe" />` somewhere obvious (e.g. inside `GuessFeedback` unconditionally). Run dev server, confirm:
+- The chip appears with the lightbulb prefix, indigo accent, the word "Hint:" muted.
+- A one-time light sweep crosses left-to-right on mount.
+- A soft glow pulses gently after the shimmer ends.
+- Visually distinct from the amber ingredient chips already on screen.
+
+Remove the temporary render before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/RegionHintChip.tsx src/app/globals.css
+git commit -m "feat(hints): RegionHintChip component with lightbulb + shimmer + glow"
+```
+
+## Task 3.3: Wire the hint into `GuessFeedback`
+
+**Files:**
+- Modify: `src/components/GuessFeedback.tsx`
+
+- [ ] **Step 1: Add the trigger and the render**
+
+Replace the body of `src/components/GuessFeedback.tsx`:
+
+```tsx
+"use client";
+
+import { useGameStore } from "@/store";
+import { AnimatePresence, motion } from "framer-motion";
+import { getCuisineRegion } from "@/data/cuisineRegions";
+import { RegionHintChip } from "./RegionHintChip";
+
+export const GuessFeedback = () => {
+  const { currentDish, gamePhase, revealedIngredients, dishGuesses } = useGameStore();
+
+  if (!currentDish) return null;
+
+  const showIngredientHints =
+    gamePhase !== "country" && revealedIngredients >= 1;
+
+  const isDishPhase = gamePhase === "dish";
+  const region = isDishPhase ? getCuisineRegion(currentDish.country) : null;
+  const showRegionHint =
+    isDishPhase && dishGuesses.length >= 3 && region !== null;
+
+  // Early return only when there's truly nothing to show.
+  if (!showIngredientHints && !showRegionHint) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {showIngredientHints && revealedIngredients > 1 && (
+        <div className="flex flex-col gap-1">
+          <div className="text-sm text-gray-600">Revealed Ingredients:</div>
+          <div className="flex flex-wrap gap-1">
+            <AnimatePresence initial={false}>
+              {currentDish.ingredients
+                .slice(0, revealedIngredients - 1)
+                .map((ingredient, index) => (
+                  <motion.li
+                    key={index}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -8 }}
+                    transition={{ duration: 0.3 }}
+                    className="px-2 py-1 text-xs bg-amber-100 text-amber-800 rounded border border-amber-300 list-none"
+                  >
+                    {ingredient}
+                  </motion.li>
+                ))}
+            </AnimatePresence>
+          </div>
+        </div>
+      )}
+
+      {showRegionHint && region && <RegionHintChip region={region} />}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Manually verify the trigger**
+
+Load a dish you know the country of (or check the local store via devtools). Make:
+- 1st wrong guess — no region chip yet.
+- 2nd wrong guess — no region chip yet.
+- 3rd wrong guess — chip appears with shimmer + glow below the ingredient row.
+- 4th wrong guess — chip persists, does NOT re-shimmer.
+
+For a dish whose country is *not* in `CUISINE_REGIONS` (you can temporarily delete its mapping to test): make 3 wrong guesses — no chip renders, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/GuessFeedback.tsx
+git commit -m "feat(hints): show cuisine-region chip after 3rd wrong dish guess"
+```
+
+---
+
+# Section 4 — Image generation upgrade
+
+## Task 4.1: Define the `ImageGenerator` interface
+
+**Files:**
+- Create: `src/services/imageGenerators/types.ts`
+
+- [ ] **Step 1: Create the interface file**
+
+Create `src/services/imageGenerators/types.ts`:
+
+```ts
+export interface ImageGenerationOpts {
+  width: number;
+  height: number;
+}
+
+export interface ImageGenerationResult {
+  /** Direct URL to the generated image (typically expires; consumers re-host). */
+  url: string;
+  /** Cost of this single generation in USD. */
+  cost: number;
+  /** Provider/model identifier for downstream tracking. */
+  source: string;
+}
+
+export interface ImageGenerator {
+  generate(prompt: string, opts: ImageGenerationOpts): Promise<ImageGenerationResult>;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/services/imageGenerators/types.ts
+git commit -m "feat(image-gen): introduce ImageGenerator adapter interface"
+```
+
+## Task 4.2: Extract the existing DALL-E 3 path behind the interface
+
+**Files:**
+- Create: `src/services/imageGenerators/openaiDallE3.ts`
+
+- [ ] **Step 1: Create the DALL-E 3 generator**
+
+Create `src/services/imageGenerators/openaiDallE3.ts`:
+
+```ts
+import OpenAI from "openai";
+import { ImageGenerator, ImageGenerationOpts, ImageGenerationResult } from "./types";
+
+export class OpenAIDallE3Generator implements ImageGenerator {
+  private openai: OpenAI;
+
+  constructor(apiKey?: string) {
+    const key = apiKey ?? process.env.OPENAI_API_KEY;
+    if (!key) throw new Error("OpenAIDallE3Generator: missing OPENAI_API_KEY");
+    this.openai = new OpenAI({ apiKey: key });
+  }
+
+  async generate(prompt: string, _opts: ImageGenerationOpts): Promise<ImageGenerationResult> {
+    // DALL-E 3 only supports a fixed set of resolutions; we keep it on the
+    // historical 1024x1024 for backwards-compatibility with existing tiles.
+    const response = await this.openai.images.generate({
+      model: "dall-e-3",
+      prompt,
+      n: 1,
+      size: "1024x1024",
+      quality: "standard",
+      style: "natural",
+    });
+
+    const url = response.data?.[0]?.url;
+    if (!url) throw new Error("OpenAIDallE3Generator: no image URL returned");
+
+    return {
+      url,
+      cost: 0.04,
+      source: "dall-e-3",
+    };
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/services/imageGenerators/openaiDallE3.ts
+git commit -m "feat(image-gen): extract DALL-E 3 path behind ImageGenerator interface"
+```
+
+## Task 4.3: Build the Google Imagen 4 Ultra generator
+
+**Files:**
+- Create: `src/services/imageGenerators/googleImagen4Ultra.ts`
+
+- [ ] **Step 1: Install the Google GenAI SDK**
+
+```bash
+npm install @google/genai
+```
+
+- [ ] **Step 2: Look up the current Imagen API surface in `@google/genai`**
+
+Open `node_modules/@google/genai/dist/index.d.ts` (or the equivalent path post-install) and find the image-generation method. As of the package's current Imagen support, generation is done via something like:
+
+```ts
+const ai = new GoogleGenAI({ apiKey });
+const result = await ai.models.generateImages({
+  model: "imagen-4.0-ultra-generate-001",
+  prompt,
+  config: {
+    numberOfImages: 1,
+    aspectRatio: "3:2",
+  },
+});
+const imageBytes = result.generatedImages?.[0]?.image?.imageBytes; // base64
+```
+
+If the actual SDK shape differs (the field names sometimes drift between versions), prefer the shape that matches the installed `@google/genai` `.d.ts`. The contract you need is: send a prompt + model + aspect ratio, receive bytes back.
+
+- [ ] **Step 3: Create the generator**
+
+Create `src/services/imageGenerators/googleImagen4Ultra.ts`:
+
+```ts
+import { GoogleGenAI } from "@google/genai";
+import { ImageGenerator, ImageGenerationOpts, ImageGenerationResult } from "./types";
+
+const MODEL_ID = "imagen-4.0-ultra-generate-001";
+const COST_PER_IMAGE_USD = 0.06;
+
+export class GoogleImagen4UltraGenerator implements ImageGenerator {
+  private ai: GoogleGenAI;
+
+  constructor(apiKey?: string) {
+    const key = apiKey ?? process.env.GEMINI_API_KEY;
+    if (!key) throw new Error("GoogleImagen4UltraGenerator: missing GEMINI_API_KEY");
+    this.ai = new GoogleGenAI({ apiKey: key });
+  }
+
+  async generate(prompt: string, opts: ImageGenerationOpts): Promise<ImageGenerationResult> {
+    // Only 3:2 is supported by this generator right now (matches our tile aspect).
+    if (opts.width !== 1536 || opts.height !== 1024) {
+      throw new Error(
+        `GoogleImagen4UltraGenerator: unsupported size ${opts.width}x${opts.height}; expected 1536x1024 (3:2)`
+      );
+    }
+
+    const result = await this.ai.models.generateImages({
+      model: MODEL_ID,
+      prompt,
+      config: {
+        numberOfImages: 1,
+        aspectRatio: "3:2",
+      },
+    });
+
+    const imageBytes = result.generatedImages?.[0]?.image?.imageBytes;
+    if (!imageBytes) throw new Error("GoogleImagen4UltraGenerator: no image bytes returned");
+
+    // Convert base64 bytes to a data URL so the existing uploadImageToSupabase
+    // (which fetches the URL via fetch()) can consume it without code changes.
+    const url = `data:image/png;base64,${imageBytes}`;
+
+    return {
+      url,
+      cost: COST_PER_IMAGE_USD,
+      source: "imagen-4-ultra",
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Confirm `uploadImageToSupabase` can handle `data:` URLs**
+
+Read `src/services/dishImageService.ts` line ~170 (`uploadImageToSupabase`). It uses `fetch(imageUrl)`. `fetch` in modern Node 20 accepts `data:` URLs natively (added in Node 20). If for some reason the existing code path fails on `data:` URLs in your environment, fall back to decoding the base64 directly in the generator and returning a temporary `https://` URL via a Supabase pre-signed upload — but try the simple path first; it almost certainly works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json src/services/imageGenerators/googleImagen4Ultra.ts
+git commit -m "feat(image-gen): add Google Imagen 4 Ultra generator (1536x1024 3:2)"
+```
+
+## Task 4.4: Add the generator barrel + default selector
+
+**Files:**
+- Create: `src/services/imageGenerators/index.ts`
+
+- [ ] **Step 1: Create the barrel + factory**
+
+Create `src/services/imageGenerators/index.ts`:
+
+```ts
+import { GoogleImagen4UltraGenerator } from "./googleImagen4Ultra";
+import { OpenAIDallE3Generator } from "./openaiDallE3";
+import { ImageGenerator } from "./types";
+
+export type { ImageGenerator, ImageGenerationOpts, ImageGenerationResult } from "./types";
+export { GoogleImagen4UltraGenerator, OpenAIDallE3Generator };
+
+/**
+ * Returns the configured default ImageGenerator.
+ * Set IMAGE_GENERATOR=dall-e-3 in env to fall back to the old path
+ * (e.g. for emergency rollback). Defaults to Imagen 4 Ultra.
+ */
+export function createDefaultImageGenerator(): ImageGenerator {
+  const which = (process.env.IMAGE_GENERATOR ?? "imagen-4-ultra").toLowerCase();
+  switch (which) {
+    case "dall-e-3":
+      return new OpenAIDallE3Generator();
+    case "imagen-4-ultra":
+    default:
+      return new GoogleImagen4UltraGenerator();
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/services/imageGenerators/index.ts
+git commit -m "feat(image-gen): add generator barrel + IMAGE_GENERATOR env-driven selector"
+```
+
+## Task 4.5: Rewrite `createOptimizedPrompt` to the cinematographic template
+
+**Files:**
+- Modify: `src/services/dishImageService.ts`
+
+- [ ] **Step 1: Replace `createOptimizedPrompt` and `getDishStyle`**
+
+In `src/services/dishImageService.ts`, replace the existing `createOptimizedPrompt` method (line ~86) AND the existing `getDishStyle` method (line ~109) with the new helpers:
+
+```ts
+private createOptimizedPrompt(dishData: DishImageData): string {
+  const { name, ingredients, country, blurb, tags } = dishData;
+  const text = [...tags, blurb].join(" ").toLowerCase();
+  const angle = this.getCameraAngle(text);
+  const surface = this.getSurface(text);
+  const cookingCue = this.getCookingCue(text);
+  const visibleIngredients = ingredients.slice(0, 3).join(", ");
+
+  return (
+    `${angle} photograph of ${name}, traditional dish from ${country}. ` +
+    `${cookingCue}, plated with ${visibleIngredients}. ` +
+    `Soft natural daylight from the left, ${surface} background, ` +
+    `shallow depth of field with the plate centered in frame. ` +
+    `Editorial food photography, 50mm lens, warm color grading, restaurant magazine quality.`
+  );
+}
+
+private getCameraAngle(text: string): string {
+  if (/(soup|stew|ramen|broth|curry)/.test(text)) return "45-degree close-up";
+  if (/(street food|handheld|sandwich|taco|burger|wrap)/.test(text)) return "Eye-level close-up";
+  return "Overhead";
+}
+
+private getSurface(text: string): string {
+  if (/(fine dining|elegant|refined)/.test(text)) return "dark slate";
+  if (/(street food|market|casual)/.test(text)) return "weathered concrete";
+  return "rustic weathered wood";
+}
+
+private getCookingCue(text: string): string {
+  const cues: string[] = [];
+  if (/(grilled|bbq|charred)/.test(text)) cues.push("deep char marks, glossy marinade");
+  if (/fried/.test(text)) cues.push("golden brown crispy crust, light oil sheen");
+  if (/(baked|roasted)/.test(text)) cues.push("caramelized crust, deep golden tones");
+  if (/steamed/.test(text)) cues.push("tender moist surface, subtle steam rising");
+  if (/(creamy|rich)/.test(text)) cues.push("velvety sauce with glossy sheen");
+  if (/(noodles|pasta)/.test(text)) cues.push("perfectly twirled strands, sauce clinging to each");
+  if (/(soup|stew)/.test(text)) cues.push("rich broth catching the light, ingredients half-submerged");
+  if (/(spicy|hot)/.test(text)) cues.push("deep red and orange tones");
+  if (/(fresh|salad|raw)/.test(text)) cues.push("vibrant raw textures, glistening dressing");
+  return cues.length ? cues.join(", ") : "rich textures and natural colors";
+}
+```
+
+- [ ] **Step 2: Eyeball-verify the prompt output**
+
+Add a temporary console log inside `generateDishImage` printing the full prompt before the API call. Run any single-dish smoke test (the existing `scripts/test-single-dish.ts` or the daily generator pointed at a known dish). Confirm the printed prompt:
+- Starts with one of "Overhead" / "45-degree close-up" / "Eye-level close-up".
+- Does NOT contain the old "appetizing", "vibrant colors", or "perfectly centered" repetitions.
+- Mentions a single camera angle (no "or").
+- Ends with the cinematographic phrasing ("50mm lens, warm color grading, restaurant magazine quality.").
+
+Remove the temporary console.log.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/dishImageService.ts
+git commit -m "feat(image-gen): replace DALL-E hedging prompt with cinematographic template"
+```
+
+## Task 4.6: Make `DishImageService` use the configured generator at 3:2
+
+**Files:**
+- Modify: `src/services/dishImageService.ts`
+
+- [ ] **Step 1: Switch from direct OpenAI calls to the adapter**
+
+At the top of `src/services/dishImageService.ts`, add:
+
+```ts
+import { createDefaultImageGenerator, ImageGenerator } from "./imageGenerators";
+```
+
+In the class field declarations, replace `private openai: OpenAI;` with:
+
+```ts
+private generator: ImageGenerator;
+private supabase: ReturnType<typeof createClient>;
+```
+
+In the constructor, replace the OpenAI initialization with:
+
+```ts
+constructor() {
+  this.generator = createDefaultImageGenerator();
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  this.supabase = createClient(supabaseUrl, supabaseServiceKey);
+}
+```
+
+- [ ] **Step 2: Replace the `generateDishImage` body with the adapter call**
+
+Replace the body of `generateDishImage` (the part inside the try block, lines ~46–76):
+
+```ts
+async generateDishImage(dishData: DishImageData): Promise<ImageGenerationResult> {
+  try {
+    console.log(`🎨 Generating image for: ${dishData.name}`);
+    const prompt = this.createOptimizedPrompt(dishData);
+    console.log(`📝 Using prompt: ${prompt.substring(0, 100)}…`);
+
+    const result = await this.generator.generate(prompt, { width: 1536, height: 1024 });
+
+    const { filename, publicUrl } = await this.uploadImageToSupabase(result.url);
+    console.log(`✅ Image generated and uploaded to Supabase: ${filename}`);
+
+    return {
+      imageUrl: publicUrl,
+      source: result.source as "dall-e-3", // existing return type accepts string literal; widen if needed
+      cost: result.cost,
+      prompt,
+      filename,
+    };
+  } catch (error) {
+    console.error(`💥 Image generation failed for ${dishData.name}:`, error);
+    throw error;
+  }
+}
+```
+
+Also update the existing local `ImageGenerationResult` interface at the top of the file to widen `source` from `"dall-e-3"` to `string` (since the value now varies by generator).
+
+- [ ] **Step 3: Update `generateImageVariations` to use the adapter too**
+
+In the same file, in `generateImageVariations` (around line 212), replace each `this.openai.images.generate({...})` call with `this.generator.generate(prompt, { width: 1536, height: 1024 })` following the same pattern as in Step 2. Drop the in-loop `imageUrl: publicUrl || "/images/404.png"` defensiveness — let exceptions bubble per the existing catch-and-continue.
+
+- [ ] **Step 4: Delete the unused OpenAI import**
+
+Since the direct `OpenAI` client is no longer instantiated in this file, remove `import OpenAI from "openai";` from the top of `dishImageService.ts`.
+
+- [ ] **Step 5: Smoke-test with the new generator**
+
+Set `GEMINI_API_KEY` in `.env.local` (use a personal API key from https://aistudio.google.com). Run a single-dish generation:
+
+```bash
+npx tsx scripts/test-single-dish.ts
+```
+
+Confirm:
+- Generation succeeds.
+- The saved image is 1536×1024 (check via Supabase storage or by downloading it).
+- The image visibly resembles the cinematographic prompt — single angle, food magazine quality, no "uncanny" DALL-E artifacts.
+- The cost logged is `0.06`.
+- The source recorded is `imagen-4-ultra`.
+
+Then sanity-check rollback works: set `IMAGE_GENERATOR=dall-e-3` in `.env.local`, rerun the smoke test — generation should succeed via DALL-E 3 producing a 1024×1024 image (which will still be tile-able via the existing crop fallback added in Task 4.7). Unset the env var to restore Imagen as default.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/dishImageService.ts
+git commit -m "feat(image-gen): swap DishImageService to use ImageGenerator adapter at 1536x1024"
+```
+
+## Task 4.7: Skip resize-to-3:2 step in `generateTiles` when source already matches
+
+**Files:**
+- Modify: `scripts/daily-generate.ts`
+
+- [ ] **Step 1: Update `generateTiles`**
+
+In `scripts/daily-generate.ts`, replace the body of `generateTiles` (lines ~536–612) — specifically the resize math block (~552–562) — with:
+
+```ts
+async function generateTiles(
+  supabase: any,
+  dishId: number,
+  imageUrl: string
+): Promise<void> {
+  const { default: Sharp } = await import("sharp");
+
+  const imageResponse = await fetch(imageUrl);
+  if (!imageResponse.ok) throw new Error(`Failed to fetch image: ${imageUrl}`);
+  const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+
+  const image = (Sharp as any)(imageBuffer);
+  const metadata = await image.metadata();
+  if (!metadata.width || !metadata.height)
+    throw new Error("Invalid image metadata");
+
+  const targetAspectRatio = 3 / 2;
+  const currentAspectRatio = metadata.width / metadata.height;
+  const aspectMatches = Math.abs(currentAspectRatio - targetAspectRatio) < 0.01;
+
+  let baseImage: any;
+  let resizeWidth: number;
+  let resizeHeight: number;
+
+  if (aspectMatches) {
+    // Source is already 3:2 (Imagen 4 Ultra path) — tile directly, no resize.
+    resizeWidth = metadata.width;
+    resizeHeight = metadata.height;
+    baseImage = image;
+  } else {
+    // Source is square (DALL-E 3 fallback) — keep the historical fit-crop path.
+    if (currentAspectRatio > targetAspectRatio) {
+      resizeHeight = metadata.height;
+      resizeWidth = Math.round(resizeHeight * targetAspectRatio);
+    } else {
+      resizeWidth = metadata.width;
+      resizeHeight = Math.round(resizeWidth / targetAspectRatio);
+    }
+    baseImage = image.resize(resizeWidth, resizeHeight, {
+      fit: "cover",
+      position: "center",
+    });
+  }
+
+  const cols = 3;
+  const rows = 2;
+  for (let tileIndex = 0; tileIndex < 6; tileIndex++) {
+    const row = Math.floor(tileIndex / cols);
+    const col = tileIndex % cols;
+    const tileWidth = Math.floor(resizeWidth / cols);
+    const tileHeight = Math.floor(resizeHeight / rows);
+    const left = col * tileWidth;
+    const top = row * tileHeight;
+    const actualWidth = col === cols - 1 ? resizeWidth - left : tileWidth;
+    const actualHeight = row === rows - 1 ? resizeHeight - top : tileHeight;
+
+    const regularTileBuffer = await baseImage
+      .clone()
+      .extract({ left, top, width: actualWidth, height: actualHeight })
+      .jpeg({ quality: 92, progressive: false })
+      .toBuffer();
+
+    const blurredTileBuffer = await baseImage
+      .clone()
+      .extract({ left, top, width: actualWidth, height: actualHeight })
+      .blur(40)
+      .modulate({ brightness: 0.8, saturation: 0.6 })
+      .jpeg({ quality: 40 })
+      .toBuffer();
+
+    const filenameRegular = `tiles/${dishId}/regular-${tileIndex}.jpg`;
+    const filenameBlurred = `tiles/${dishId}/blurred-${tileIndex}.jpg`;
+
+    const { error: upErr1 } = await supabase.storage
+      .from("dish-tiles")
+      .upload(filenameRegular, regularTileBuffer, {
+        contentType: "image/jpeg",
+        upsert: true,
+      });
+    if (upErr1) throw new Error(upErr1.message);
+
+    const { error: upErr2 } = await supabase.storage
+      .from("dish-tiles")
+      .upload(filenameBlurred, blurredTileBuffer, {
+        contentType: "image/jpeg",
+        upsert: true,
+      });
+    if (upErr2) throw new Error(upErr2.message);
+  }
+}
+```
+
+- [ ] **Step 2: Smoke-test tile generation**
+
+Run a full end-to-end generation against a staging DB (or your local Supabase):
+
+```bash
+npx tsx scripts/daily-generate.ts
+```
+
+Look in Supabase storage `dish-tiles/<dishId>/`:
+- 6 `regular-*.jpg` files exist.
+- 6 `blurred-*.jpg` files exist.
+- Combined visually they reconstruct the full image (no gaps, no overlap).
+
+Play the generated dish via the dev server — the tile grid should render and reveal correctly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/daily-generate.ts
+git commit -m "feat(tiles): skip resize-to-3:2 when source image already matches the target aspect"
+```
+
+## Task 4.8: Add `GEMINI_API_KEY` to the daily-generate workflow
+
+**Files:**
+- Modify: `.github/workflows/daily-generate.yml`
+
+- [ ] **Step 1: Add the secret to the .env.local heredoc**
+
+In `.github/workflows/daily-generate.yml`, in the "Create .env.local" step, add a line for `GEMINI_API_KEY`:
+
+```yaml
+      - name: Create .env.local
+        run: |
+          cat > .env.local << 'EOF'
+          OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          DAILY_COST_CAP_USD=${{ secrets.DAILY_COST_CAP_USD }}
+          TARGET_BUFFER_DAYS=${{ secrets.TARGET_BUFFER_DAYS }}
+          EOF
+```
+
+- [ ] **Step 2: Add the secret to the GitHub repo**
+
+In the GitHub repo settings → Secrets and variables → Actions → New repository secret:
+- Name: `GEMINI_API_KEY`
+- Value: your Imagen API key from https://aistudio.google.com
+
+(This is a manual step done in the GitHub UI, not in code. Skip if the team handles secrets via a different mechanism — just ensure the secret exists by the time the workflow next runs.)
+
+- [ ] **Step 3: Manually trigger the workflow to verify**
+
+In GitHub Actions → Daily Dish Generation → Run workflow (workflow_dispatch).
+
+Watch the run logs:
+- "Create .env.local" step succeeds.
+- "Run daily generator" step logs `🎨 Generating image for: <name>` followed by a successful Supabase upload.
+- No `GEMINI_API_KEY missing` errors.
+
+If the buffer is already full (`bufferDays >= TARGET_BUFFER_DAYS`) the script will short-circuit. To force a generation, temporarily lower `TARGET_BUFFER_DAYS` in the workflow secrets, run, then restore. Or pick any dish in the database, delete it, and re-run — but that's destructive, avoid unless needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/daily-generate.yml
+git commit -m "ci(daily-generate): pass GEMINI_API_KEY into the workflow env file"
+```
+
+---
+
+## Final Verification
+
+Walk through the complete play-through once with all changes integrated:
+
+- [ ] Load `/play` — text input is auto-focused on desktop (not mobile).
+- [ ] Header shows the 🔥 streak chip if your streak is ≥1.
+- [ ] Type a wrong dish guess — get an ingredient hint.
+- [ ] After the 3rd wrong dish guess — region hint chip appears below ingredients, shimmer + glow visible, clearly distinct from amber ingredient chips.
+- [ ] Try a known short-form for a recently-generated dish — accepted via fuzzy match.
+- [ ] Click the give-up button — confirm it reads "🏳️ Give up" outline style, opens the confirm dialog.
+- [ ] Solve the dish — advance to country phase (autofocus there too).
+- [ ] Solve country and protein — results modal appears (Radix, dismissible via Esc / outside-click / X).
+- [ ] Dismiss the modal — "View Results" button appears at the bottom of the protein phase. Click it — modal re-opens, no duplicate score submission.
+- [ ] Open archive picker — confirm 90 days of past dates are selectable.
+- [ ] Visit `/statistics` — streak chip on the header still works there if it's visible across routes (it is — `GameHeader` is shared).
+- [ ] Visually compare the dish image (newly generated, Imagen 4 Ultra) against an older DALL-E 3 dish image side by side — the new one should look noticeably better.

--- a/docs/superpowers/specs/2026-05-22-game-experience-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-22-game-experience-improvements-design.md
@@ -1,0 +1,312 @@
+# Game Experience Improvements — Design
+
+A bundle of UX, gameplay, and content-quality improvements to the daily dish-guessing game. Scoped to changes that don't require new backend infrastructure beyond swapping the image generation provider.
+
+## Goals
+
+- Reduce small friction points in the play loop (modal close, autofocus, give-up affordance, streak visibility).
+- Make dishes more guessable by widening the accepted answer set without making the game trivial.
+- Add a single, well-emphasized progressive hint that complements (not duplicates) the existing ingredient-reveal mechanic.
+- Replace the current image generation model with a higher-quality, similarly-priced alternative, and lean into a cleaner prompt style.
+- Expand archive access from 30 days to 90 days.
+
+## Non-Goals
+
+- No changes to scoring, leaderboard math, or the protein/country phase core mechanics.
+- No re-design of the share modal, statistics page, or onboarding/intro flow.
+- No phase auto-advance after a correct guess (decided out of scope).
+- No new runtime LLM calls for guess evaluation (deferred — re-evaluate after Section 3 ships and analytics show whether near-miss frustration persists).
+- No new backend services. The image-model swap stays inside `daily-generate.ts` and `dishImageService.ts`.
+
+## Architecture Overview
+
+The improvements split into four loosely-coupled areas, each shippable in its own PR:
+
+1. **Small UX wins** — modal dismiss, autofocus, give-up button, streak chip, archive range.
+2. **Guess acceptance widening** — broaden AI-generated `acceptableGuesses` + auto-accept high-confidence fuzzy matches at runtime.
+3. **Cuisine-region progressive hint** — new chip after the 3rd wrong dish guess, with a distinct visual treatment to mark it as a clue.
+4. **Image generation upgrade** — DALL-E 3 → Imagen 4 Ultra (via fal.ai), at 3:2 native, with a leaner cinematographic prompt.
+
+All four can ship independently and in any order. There are no cross-cutting state/store changes required.
+
+---
+
+## Section 1 — Small UX wins
+
+### 1.1 Result modal: ESC + outside-click dismiss
+
+**Current state:** `src/components/ResultModal.tsx:138` renders a raw `<div>` overlay with a single `✕` button as the only dismiss path. No keyboard or backdrop handling.
+
+**Change:** replace the raw overlay with the existing Radix-based `Dialog` (already used in `ArchiveDatePicker.tsx` and `GiveUpButton.tsx`). Radix handles ESC and outside-click natively via `onOpenChange`. Modal open state is bound to the existing `modalVisible` store flag.
+
+**Mid-game re-open safety:** once the modal is closed mid-day, the player should never lose access to their final results. When `gamePhase === "complete"` and `modalVisible === false`, render a persistent **"View Results"** button at the bottom of the protein-phase complete view. Clicking re-opens the modal via `toggleModal(true)`. No new state needed.
+
+### 1.2 Autofocus text input on game entry — desktop only
+
+**Current state:** `TextInput` in `src/components/inputs/TextInput.tsx:134` is not autofocused. Players have to click before typing.
+
+**Change:** add autofocus on mount when the active phase is `dish` or `country` (both text-input phases) **and** the device is non-touch. Touch detection via `window.matchMedia('(hover: hover) and (pointer: fine)').matches` — true on desktop/laptop, false on mobile/tablet, avoids popping the mobile keyboard.
+
+Implementation: `useRef<HTMLInputElement>` on the `Input` inside `TextInput`, focus call in a `useEffect` gated by the media query. No focus on `NumberInput` (protein phase) — that one's less essential and the iOS numeric keyboard popping uninvited is more disruptive.
+
+### 1.3 Give-up button — clearer affordance, consistent across phases
+
+**Current state:** `GiveUpButton.tsx` renders a red-background button with only a `/images/give-up.png` flag icon. Functional but cryptic. A secondary "Give up and see results" text link exists in `GuessInput.tsx:219` but only for the protein phase at ≥3 guesses — that secondary path is inconsistent with the other phases.
+
+**Change:**
+- Replace the icon-only button with an outline button: `🏳️ Give up` (icon + label). Same `GiveUpButton.tsx` component, same confirm dialog. Just a visual swap so it reads as an action.
+- Remove the secondary "Give up and see results" link from `GuessInput.tsx` — the primary button is now clear enough on its own.
+- No conditioning on guess count — flag is available immediately in every phase.
+
+### 1.4 Streak chip in header
+
+**Current state:** the 🔥 streak indicator only appears inside the post-game result modal.
+
+**Change:** render a small streak chip in `GameHeader.tsx` next to the Statistics button, **only when `streak ≥ 1`**. Reuses the existing `streak` value from `useGameStore`. Tapping it routes to `/statistics`. Visual style matches the in-modal version (orange/red, 🔥 emoji prefix).
+
+### 1.5 Archive range: 30 → 90 days
+
+**Current state:** `src/components/ArchiveDatePicker.tsx:34` hard-codes a 30-day window.
+
+**Change:** bump the constant to 90 days. Verify that the `/api/archive-unlock` and `/api/dishes?date=...` paths don't impose their own 30-day cap. If they do, lift those too.
+
+---
+
+## Section 2 — Widen dish acceptance
+
+### 2.1 Broader `acceptableGuesses` at generation time
+
+**Current state:** `src/services/aiService.ts:148` prompts the AI for `2-4 smart variations`. Result is often too narrow — e.g. "piri piri" is rejected for "Piri-piri Chicken" (see attached gameplay screenshot, guess #2).
+
+**Change:** update the prompt to request **6 to 10 variations** covering:
+- Common misnames and shortened forms (e.g. "piri piri", "peri peri chicken").
+- English vs. native-language names where both are commonly used.
+- Singular and plural forms.
+- Common alternate spellings and regional variants.
+
+Validation in `validateDishData` updated to require `acceptableGuesses.length >= 6`.
+
+**Backfill:** existing dishes in the database keep their narrower lists. We don't retroactively regenerate — but we *do* add a one-off script `scripts/expand-acceptable-guesses.ts` that takes the existing dish list and asks the AI to extend each `acceptableGuesses` array to the new 6–10 target. Idempotent (skips dishes already at ≥6 variations). Cost is bounded — ~$0.001 per dish via gpt-4o-mini, run once.
+
+### 2.2 Auto-accept high-confidence fuzzy matches at runtime
+
+**Current state:** `src/utils/gameHelpers.ts:181` (`getClosestGuess`) only ever returns a suggestion to render as a "Did you mean X?" toast — never marks the guess correct directly.
+
+**Change:** introduce a new helper `getStrongFuzzyMatch(input, options)` that returns a match only when confidence is *very* high — fuse.js score ≤ 0.15, OR a meaningful exact-substring containment with length ratio ≥ 0.5. In `DishPhase.tsx:36`, the dish-correctness check becomes:
+
+```ts
+const isCorrect =
+  currentDish?.acceptableGuesses?.includes(guess.toLowerCase()) ||
+  !!getStrongFuzzyMatch(guess, currentDish?.acceptableGuesses ?? []);
+```
+
+When the fuzzy match wins, the canonical form is stored in `dishGuesses` (not the raw input) so the UI shows the player they got it right with the "real" answer.
+
+`getClosestGuess` continues to handle the looser "did you mean?" suggestion case for typos that aren't quite confident enough to auto-accept.
+
+---
+
+## Section 3 — Cuisine-region progressive hint
+
+**Background:** the existing wrong-guess feedback already reveals ingredients one by one (`GuessFeedback.tsx`, driven by `revealedIngredients` in the game store). `reorderIngredientsForGameplay` ensures the first revealed ingredients are "safe" — they don't appear in `acceptableGuesses`. This existing mechanic is good and stays unchanged.
+
+**Change:** add **one** additional hint type — cuisine region — that complements the ingredient reveals rather than duplicating them.
+
+### 3.1 Region data
+
+New file `src/data/cuisineRegions.ts`:
+
+```ts
+export const CUISINE_REGIONS: Record<string, string> = {
+  Portugal: "Iberian / Southern Europe",
+  Spain: "Iberian / Southern Europe",
+  Thailand: "Southeast Asia",
+  Japan: "East Asia",
+  // ...one entry per country currently in the dishes table
+};
+
+export function getCuisineRegion(country: string): string | null {
+  return CUISINE_REGIONS[country] ?? null;
+}
+```
+
+Generated once from the existing list of distinct `country` values in the dishes table. Manual curation — there are only ~50 countries.
+
+### 3.2 Trigger and display
+
+**Trigger:** appears after the **3rd wrong dish guess** (i.e. when `dishGuesses.length === 3` and the most recent guess was wrong). Persists for the rest of the dish phase. No additional hint chips after this one.
+
+**Component:** new `RegionHintChip.tsx` rendered inside `GuessFeedback.tsx`, below the existing ingredient chip row. Only renders during the dish phase, only when the trigger condition is met.
+
+**Visual treatment** (to mark it as a *clue*, distinct from the *factual* ingredient chips):
+- 💡 lightbulb icon prefix.
+- Soft indigo / lavender accent (distinct from the amber ingredient chips).
+- One-time shimmer sweep on first appearance (CSS keyframe animation, ~1.2s, runs once).
+- Subtle pulsing glow that persists (low-intensity, doesn't compete for attention after the first second).
+
+**Copy:** `💡 Hint: {region}` — e.g. `💡 Hint: Iberian / Southern Europe`.
+
+**Fallback:** if `getCuisineRegion(country)` returns null (unmapped country), the chip doesn't render. No error.
+
+---
+
+## Section 4 — Image generation upgrade
+
+### 4.1 Model swap: DALL-E 3 → Imagen 4 Ultra via Google Gemini Developer API
+
+**Current state:** `src/services/dishImageService.ts:49` calls `openai.images.generate({ model: "dall-e-3", ... })` at `1024×1024`, `standard` quality, ~$0.04/image. DALL-E 3 is now ~2 years old; bake-off (3 contenders × 4 dishes on fal.ai's playground) confirmed Imagen 4 Ultra as the best quality-per-dollar for this game's plated-food aesthetic. We integrate against Google directly (not fal.ai) — same model, no middleman markup, no extra account.
+
+**Sunset awareness:** Google has signalled that the Imagen 4 family is scheduled for deprecation on/around June 24, 2026 with a planned migration path to Gemini Image / Nano Banana models. At today's pricing Nano Banana is ~5x more expensive ($0.30 vs $0.06), so it's not a drop-in replacement we'd want to make pre-emptively. The adapter pattern below makes the eventual swap a ~1-day change. A follow-up task (see Open Questions) tracks revisiting this in mid-June.
+
+**Change:**
+- Add Google Gemini Developer API integration via the `@google/genai` package — API-key auth (`GEMINI_API_KEY`), same shape as the existing `OPENAI_API_KEY`. No GCP project / service account / Vertex setup required.
+- Replace the OpenAI `images.generate` call in `generateDishImage` with a Gemini API call to model `imagen-4.0-ultra-generate-001`.
+- Output resolution: **`1536×1024` (3:2 aspect)** native — eliminates the post-generation crop step in `daily-generate.ts:552-562` (`generateTiles` previously had to compute a target 3:2 box and crop the square down).
+- The `uploadImageToSupabase` flow (download → hash → upload to `dish-images-v2` bucket) stays unchanged.
+- New env var: `GEMINI_API_KEY` (read in `dishImageService.ts` constructor alongside the existing `SUPABASE_*` vars; also added to the GitHub Actions secrets used by the `daily-generate` workflow).
+- Update `ImageGenerationResult.source` from `"dall-e-3"` to `"imagen-4-ultra"`.
+- Cost field: `0.06` per image (up from `0.04`). At ~1 dish/day, monthly cost stays under $2.
+
+**Thin adapter for future swaps:** factor the model call behind a small interface so the model is one config flip:
+
+```ts
+interface ImageGenerator {
+  generate(prompt: string, opts: { width: number; height: number }): Promise<{ url: string; cost: number }>;
+}
+
+class GoogleImagen4UltraGenerator implements ImageGenerator { ... }
+class OpenAIDallE3Generator implements ImageGenerator { ... } // kept as fallback / for reference
+```
+
+`DishImageService` constructs the configured generator and calls it. Default: `GoogleImagen4UltraGenerator`. Pre-sunset migration adds a third class (`GoogleNanoBananaGenerator` or whichever replacement we settle on) and flips the default.
+
+### 4.2 New cinematographic prompt template
+
+**Current state:** `createOptimizedPrompt` in `dishImageService.ts:86` and `getDishStyle` at line 109 produce a prompt that triple-repeats "centered", hedges "overhead OR 45-degree", and front-loads adjective hedging ("appetizing", "vibrant") that were DALL-E 3 workarounds. Modern models reward specificity.
+
+**Change:** rewrite `createOptimizedPrompt` and replace `getDishStyle` with three smaller helpers that return cinematographic phrasing instead of adjectives:
+
+```ts
+private createOptimizedPrompt(dishData: DishImageData): string {
+  const { name, ingredients, country, blurb, tags } = dishData;
+  const text = [...tags, blurb].join(" ").toLowerCase();
+  const angle = this.getCameraAngle(text);
+  const surface = this.getSurface(text);
+  const cookingCue = this.getCookingCue(text);
+  const visibleIngredients = ingredients.slice(0, 3).join(", ");
+
+  return `${angle} photograph of ${name}, traditional dish from ${country}. ` +
+    `${cookingCue}, plated with ${visibleIngredients}. ` +
+    `Soft natural daylight from the left, ${surface} background, ` +
+    `shallow depth of field with the plate centered in frame. ` +
+    `Editorial food photography, 50mm lens, warm color grading, restaurant magazine quality.`;
+}
+
+private getCameraAngle(text: string): string {
+  if (/(soup|stew|ramen|broth|curry)/.test(text)) return "45-degree close-up";
+  if (/(street food|handheld|sandwich|taco|burger|wrap)/.test(text)) return "Eye-level close-up";
+  return "Overhead";
+}
+
+private getSurface(text: string): string {
+  if (/(fine dining|elegant|refined)/.test(text)) return "dark slate";
+  if (/(street food|market|casual)/.test(text)) return "weathered concrete";
+  return "rustic weathered wood";
+}
+
+private getCookingCue(text: string): string {
+  const cues: string[] = [];
+  if (/(grilled|bbq|charred)/.test(text)) cues.push("deep char marks, glossy marinade");
+  if (/fried/.test(text)) cues.push("golden brown crispy crust, light oil sheen");
+  if (/(baked|roasted)/.test(text)) cues.push("caramelized crust, deep golden tones");
+  if (/steamed/.test(text)) cues.push("tender moist surface, subtle steam rising");
+  if (/(creamy|rich)/.test(text)) cues.push("velvety sauce with glossy sheen");
+  if (/(noodles|pasta)/.test(text)) cues.push("perfectly twirled strands, sauce clinging to each");
+  if (/(soup|stew)/.test(text)) cues.push("rich broth catching the light, ingredients half-submerged");
+  if (/(spicy|hot)/.test(text)) cues.push("deep red and orange tones");
+  if (/(fresh|salad|raw)/.test(text)) cues.push("vibrant raw textures, glistening dressing");
+  return cues.length ? cues.join(", ") : "rich textures and natural colors";
+}
+```
+
+Old `getDishStyle` and its style branches are deleted. `generateImageVariations` is updated to use the new prompt too.
+
+### 4.3 Tile generation: drop the crop step
+
+**Current state:** `daily-generate.ts:552-562` resizes the square 1024×1024 to a 3:2 fit before extracting six tiles.
+
+**Change:** when the source image is already 3:2 (1536×1024), skip the resize-and-fit math and tile directly. Falls back to the existing resize logic if a non-3:2 image is ever passed in (defensive — e.g. the DALL-E 3 fallback generator). No change to tile output dimensions, bucket layout, or `/api/dish-tiles*` consumers.
+
+---
+
+## Data Flow
+
+No new long-lived state. Summary of touched components:
+
+```
+GameHeader  ──reads──> useGameStore.streak  (new: streak chip)
+
+DishPhase ──renders──> GuessFeedback
+                          ├── existing: ingredient chips
+                          └── new: RegionHintChip (after 3rd wrong guess)
+
+GuessInput ──renders──> GiveUpButton  (new visual: outline + label)
+                       (removed: secondary "give up and see results" link)
+
+ResultModal (Radix Dialog) ──bound to──> useGameStore.modalVisible
+            └── ESC / outside-click → toggleModal(false)
+            └── persistent re-open via "View Results" in complete view
+
+ArchiveDatePicker ──constant──> 90 days (was 30)
+
+daily-generate ──> AIService (broader acceptableGuesses)
+              ──> DishImageService ──> ImageGenerator (FalImagen4Ultra)
+                                      └── 1536×1024 native, no crop
+              ──> generateTiles (skip resize when source is 3:2)
+```
+
+## Error Handling
+
+- **Region hint:** missing region → don't render. No log spam.
+- **Fuzzy auto-accept:** never relies on a single signal — both score threshold AND substring containment paths must pass independently. A failed fuzzy lookup falls through to existing "did you mean?" toast logic.
+- **fal.ai client errors:** caught in `generateDishImage` and re-thrown — `daily-generate.ts` already has a `continue` on the catch, so a single failed generation doesn't abort the batch.
+- **Missing `FAL_KEY`:** fail fast at service construction with a clear error message (matching the existing pattern for `SUPABASE_SERVICE_ROLE_KEY`).
+- **Modal close mid-game:** the "View Results" button is the safety net. No data loss possible since results are already computed and submitted by the time the modal opens.
+
+## Testing
+
+Manual verification per area:
+
+**Section 1**
+- Modal closes on `Esc`, on backdrop click, and on the `✕` button.
+- Close → re-open via "View Results" works without re-running scoring or animations.
+- Desktop: input is focused on game load and after each phase transition. Mobile: keyboard does NOT pop.
+- Give-up button shows "🏳️ Give up" label, works on first guess in all three phases.
+- Streak chip appears in header only when `streak ≥ 1`, links to `/statistics`.
+- Archive picker offers 90 days of past dates; selecting day 89 loads the correct dish.
+
+**Section 2**
+- Generate a new dish, confirm `acceptableGuesses.length >= 6`.
+- Run `scripts/expand-acceptable-guesses.ts` against staging dishes, verify each now has ≥6 entries, no duplicates.
+- Play a dish with a known short variant (e.g. "piri piri" for "Piri-piri Chicken") and confirm auto-accept.
+- Play with an obvious typo ("piri pirir") — should still show "Did you mean piri piri?" rather than auto-accepting.
+- Play with nonsense ("adasd") — no fuzzy match, no suggestion, normal wrong-guess flow.
+
+**Section 3**
+- Make 3 wrong dish guesses on a dish whose country is in the region map — chip appears with shimmer + lightbulb on the 3rd wrong guess.
+- Make 3 wrong guesses on a dish whose country is NOT in the map — no chip, no error.
+- Chip persists through subsequent wrong guesses; doesn't re-shimmer.
+- Visual matches design — distinct from amber ingredient chips.
+
+**Section 4**
+- Run `npm run daily-generate` against a staging DB.
+- Verify generated image is 1536×1024, looks visibly better than DALL-E 3 baseline, prompt logged shows the new template.
+- Verify tiles are generated correctly (6 tiles, 3:2 grid layout intact).
+- Verify game plays end-to-end with the new image — blurred tiles + full reveal both render.
+
+## Open Questions / Follow-ups
+
+- **After Section 3 ships:** revisit whether to add a 2nd hint type (e.g. dish category — "noodle dish", "stew") at the 5th wrong guess. Decide based on whether players still get stuck after the region hint.
+- **After Section 2 ships:** check PostHog `guess_dish` events for `correct: false` followed by a give-up within 1 guess — high rates suggest semantic-similarity (Option B from brainstorming) is worth adding as a fallback layer.
+- **`scripts/expand-acceptable-guesses.ts`** is a one-time backfill. After it runs in production, delete the script (don't leave dead code).
+- **Imagen 4 sunset (~June 24, 2026):** before mid-June, verify the deprecation timeline against the Google Cloud / Gemini API console, run a fresh bake-off comparing whatever Imagen-replacement Google is pushing (Nano Banana et al.) against the then-current options across providers, and add a new `ImageGenerator` implementation. Adapter pattern in Section 4.1 keeps this to a ~1-day swap. Track as a calendar reminder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "food-for-tought",
       "version": "0.1.0",
       "dependencies": {
+        "@google/genai": "^2.6.0",
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-popover": "^1.1.13",
@@ -734,6 +735,30 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@google/genai": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.6.0.tgz",
+      "integrity": "sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1490,6 +1515,69 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
@@ -2880,6 +2968,12 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/topojson-client": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
@@ -3409,6 +3503,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3776,6 +3879,35 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3843,6 +3975,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -4193,6 +4331,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4258,7 +4405,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4423,6 +4569,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.138",
@@ -5111,6 +5266,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5169,6 +5330,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -5304,6 +5488,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -5406,6 +5602,34 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5579,6 +5803,32 @@
         "csstype": "^3.0.10"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5718,6 +5968,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6276,6 +6539,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6324,6 +6596,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -6650,6 +6943,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6787,7 +7086,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -6906,6 +7204,44 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -7162,6 +7498,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -7442,6 +7791,30 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -7701,6 +8074,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7753,6 +8135,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -8909,6 +9311,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/web-vitals": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "daily-generate": "tsx scripts/daily-generate.ts"
   },
   "dependencies": {
+    "@google/genai": "^2.6.0",
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@google/genai':
+        specifier: ^2.6.0
+        version: 2.6.0
       '@radix-ui/react-dialog':
         specifier: ^1.1.13
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -390,6 +393,15 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@google/genai@2.6.0':
+    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -653,6 +665,36 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
@@ -1124,6 +1166,9 @@ packages:
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/topojson-client@3.1.5':
     resolution: {integrity: sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==}
 
@@ -1309,6 +1354,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1416,6 +1465,12 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -1434,6 +1489,9 @@ packages:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1554,6 +1612,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1636,6 +1698,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.182:
     resolution: {integrity: sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==}
@@ -1811,6 +1876,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1838,6 +1906,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
@@ -1882,6 +1954,10 @@ packages:
     resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -1917,6 +1993,14 @@ packages:
   fuse.js@7.1.0:
     resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
     engines: {node: '>=10'}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1963,6 +2047,14 @@ packages:
     peerDependencies:
       csstype: ^3.0.10
 
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2006,6 +2098,10 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2182,6 +2278,9 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2198,6 +2297,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2294,6 +2399,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2403,6 +2511,15 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -2481,6 +2598,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -2597,6 +2718,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.6.0:
+    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+    engines: {node: '>=12.0.0'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -2695,6 +2820,10 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2705,6 +2834,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -3003,6 +3135,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
@@ -3273,6 +3409,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@google/genai@2.6.0':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.6.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -3461,6 +3608,28 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@radix-ui/primitive@1.1.2': {}
 
@@ -3920,6 +4089,8 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/topojson-client@3.1.5':
     dependencies:
       '@types/geojson': 7946.0.16
@@ -4094,6 +4265,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4229,6 +4402,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
   binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.12:
@@ -4250,6 +4427,8 @@ snapshots:
       electron-to-chromium: 1.5.182
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   busboy@1.6.0:
     dependencies:
@@ -4371,6 +4550,8 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -4447,6 +4628,10 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.182: {}
 
@@ -4790,6 +4975,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -4819,6 +5006,11 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fflate@0.4.8: {}
 
@@ -4861,6 +5053,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fraction.js@4.3.7: {}
 
   framer-motion@12.23.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
@@ -4889,6 +5085,22 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   fuse.js@7.1.0: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4948,6 +5160,19 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -4981,6 +5206,13 @@ snapshots:
       function-bind: 1.1.2
 
   html-escaper@2.0.2: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   ignore@5.3.2: {}
 
@@ -5155,6 +5387,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -5171,6 +5407,17 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -5241,6 +5488,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -5336,6 +5585,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
@@ -5414,6 +5671,11 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -5509,6 +5771,21 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  protobufjs@7.6.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 20.19.7
+      long: 5.3.2
 
   proxy-from-env@1.1.0: {}
 
@@ -5609,6 +5886,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   run-parallel@1.2.0:
@@ -5622,6 +5901,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -6034,6 +6315,8 @@ snapshots:
       '@types/react': 19.1.8
 
   util-deprecate@1.0.2: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@4.2.4: {}
 

--- a/scripts/daily-generate.ts
+++ b/scripts/daily-generate.ts
@@ -551,14 +551,30 @@ async function generateTiles(
 
   const targetAspectRatio = 3 / 2;
   const currentAspectRatio = metadata.width / metadata.height;
+  const aspectMatches = Math.abs(currentAspectRatio - targetAspectRatio) < 0.01;
+
+  let baseImage: any;
   let resizeWidth: number;
   let resizeHeight: number;
-  if (currentAspectRatio > targetAspectRatio) {
-    resizeHeight = metadata.height;
-    resizeWidth = Math.round(resizeHeight * targetAspectRatio);
-  } else {
+
+  if (aspectMatches) {
+    // Source is already 3:2 (Imagen 4 Ultra path) — tile directly, no resize.
     resizeWidth = metadata.width;
-    resizeHeight = Math.round(resizeWidth / targetAspectRatio);
+    resizeHeight = metadata.height;
+    baseImage = image;
+  } else {
+    // Source is square (DALL-E 3 fallback) — keep the historical fit-crop path.
+    if (currentAspectRatio > targetAspectRatio) {
+      resizeHeight = metadata.height;
+      resizeWidth = Math.round(resizeHeight * targetAspectRatio);
+    } else {
+      resizeWidth = metadata.width;
+      resizeHeight = Math.round(resizeWidth / targetAspectRatio);
+    }
+    baseImage = image.resize(resizeWidth, resizeHeight, {
+      fit: "cover",
+      position: "center",
+    });
   }
 
   const cols = 3;
@@ -573,10 +589,6 @@ async function generateTiles(
     const actualWidth = col === cols - 1 ? resizeWidth - left : tileWidth;
     const actualHeight = row === rows - 1 ? resizeHeight - top : tileHeight;
 
-    const baseImage = image.resize(resizeWidth, resizeHeight, {
-      fit: "cover",
-      position: "center",
-    });
     const regularTileBuffer = await baseImage
       .clone()
       .extract({ left, top, width: actualWidth, height: actualHeight })

--- a/scripts/expand-acceptable-guesses.ts
+++ b/scripts/expand-acceptable-guesses.ts
@@ -1,0 +1,87 @@
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { createClient } from "@supabase/supabase-js";
+import OpenAI from "openai";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+interface DishRow {
+  id: number;
+  name: string;
+  acceptable_guesses: string[] | null;
+}
+
+async function expandOne(name: string, existing: string[]): Promise<string[]> {
+  const prompt = `Given the dish "${name}" and the current list of accepted player guesses:
+${JSON.stringify(existing)}
+
+Expand this list to 6-10 entries total. Add entries covering:
+- Shortened/common-misname forms (e.g. "piri piri" for "Piri-piri Chicken").
+- English vs. native-language names where both are commonly used.
+- Singular and plural forms.
+- Common alternate spellings and regional variants.
+
+Return ONLY a JSON array of lowercase strings. No duplicates. Preserve the existing entries.`;
+
+  const res = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0.3,
+    max_tokens: 400,
+  });
+
+  const content = res.choices[0]?.message?.content?.trim() ?? "";
+  const cleaned = content.replace(/^```json\s*/, "").replace(/```\s*$/, "");
+  const parsed = JSON.parse(cleaned) as string[];
+
+  const merged = Array.from(new Set([...existing.map((s) => s.toLowerCase()), ...parsed.map((s) => s.toLowerCase())]));
+  return merged;
+}
+
+async function main() {
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const { data, error } = await supabase
+    .from("dishes")
+    .select("id,name,acceptable_guesses");
+  if (error) throw error;
+
+  const rows = (data ?? []) as DishRow[];
+  let updated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const current = row.acceptable_guesses ?? [];
+    if (current.length >= 6) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      console.log(`🔄 Expanding ${row.name} (currently ${current.length} entries)…`);
+      const expanded = await expandOne(row.name, current);
+
+      const { error: upErr } = await supabase
+        .from("dishes")
+        .update({ acceptable_guesses: expanded })
+        .eq("id", row.id);
+      if (upErr) throw upErr;
+
+      console.log(`  ✅ Now ${expanded.length} entries.`);
+      updated++;
+    } catch (e) {
+      console.error(`  ❌ Failed for ${row.name}:`, e);
+      failed++;
+    }
+  }
+
+  console.log(`\nDone. Updated: ${updated}, Skipped (already >= 6): ${skipped}, Failed: ${failed}`);
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,3 +83,27 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes hint-glow {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.0); }
+  50%      { box-shadow: 0 0 16px 2px rgba(99, 102, 241, 0.35); }
+}
+.animate-hint-glow {
+  animation: hint-glow 2.4s ease-in-out infinite;
+}
+
+@keyframes hint-shimmer {
+  0%   { transform: translateX(-100%); opacity: 0; }
+  10%  { opacity: 0.6; }
+  60%  { opacity: 0.6; }
+  100% { transform: translateX(100%); opacity: 0; }
+}
+.animate-hint-shimmer {
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.55) 50%,
+    transparent 70%
+  );
+  animation: hint-shimmer 1.2s ease-out 0.1s 1 forwards;
+}

--- a/src/app/play/DishPhase.tsx
+++ b/src/app/play/DishPhase.tsx
@@ -2,6 +2,7 @@ import { GuessFeedback } from "@/components/GuessFeedback";
 import { GuessInput } from "@/components/GuessInput";
 import { useBlurredTiles, useDishTiles } from "@/hooks/useDishTiles";
 import { useGameStore } from "@/store";
+import { getStrongFuzzyMatch } from "@/utils/gameHelpers";
 import posthog from "posthog-js";
 import { memo } from "react";
 import { TileGrid } from "../../components/dish-image/TileGrid";
@@ -33,15 +34,22 @@ export const DishPhase = memo(() => {
   const isComplete = isDishPhaseComplete();
 
   const handleGuess = (guess: string) => {
-    const isCorrect =
-      currentDish?.acceptableGuesses?.includes(guess.toLowerCase()) ?? false;
+    const normalized = guess.toLowerCase().trim();
+    const acceptable = currentDish?.acceptableGuesses ?? [];
+
+    const exactMatch = acceptable.includes(normalized);
+    const fuzzyMatch = exactMatch ? null : getStrongFuzzyMatch(normalized, acceptable);
+
+    const isCorrect = exactMatch || !!fuzzyMatch;
+    const guessToRecord = fuzzyMatch ?? guess;
 
     posthog.capture("guess_dish", {
       guess,
       correct: isCorrect,
+      fuzzy_match: !!fuzzyMatch,
     });
 
-    guessDish(guess);
+    guessDish(guessToRecord);
   };
 
   return (

--- a/src/app/play/ProteinPhase.tsx
+++ b/src/app/play/ProteinPhase.tsx
@@ -1,5 +1,6 @@
 import { GuessInput } from "@/components/GuessInput";
 import { IngredientProteinStrip } from "@/components/IngredientProteinStrip";
+import { Button } from "@/components/ui/button";
 import { useGameStore } from "@/store";
 import { ProteinSkeleton } from "../../components/GameSkeleton";
 import { ProteinGuessFeedback } from "../../components/ProteinGuessFeedback";
@@ -13,6 +14,9 @@ export function ProteinPhase() {
     currentDish,
     isProteinPhaseComplete,
     archiveDate,
+    gamePhase,
+    modalVisible,
+    toggleModal,
   } = useGameStore();
   const { isLoading } = useTodaysDish(archiveDate);
 
@@ -57,6 +61,14 @@ export function ProteinPhase() {
         guessResults={proteinGuessResults}
         actualProtein={currentDish.proteinPerServing}
       />
+
+      {gamePhase === "complete" && !modalVisible && (
+        <div className="flex justify-center mt-4">
+          <Button variant="cta" onClick={() => toggleModal(true)}>
+            📋 View Results
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/play/ProteinPhase.tsx
+++ b/src/app/play/ProteinPhase.tsx
@@ -1,6 +1,5 @@
 import { GuessInput } from "@/components/GuessInput";
 import { IngredientProteinStrip } from "@/components/IngredientProteinStrip";
-import { Button } from "@/components/ui/button";
 import { useGameStore } from "@/store";
 import { ProteinSkeleton } from "../../components/GameSkeleton";
 import { ProteinGuessFeedback } from "../../components/ProteinGuessFeedback";
@@ -14,9 +13,6 @@ export function ProteinPhase() {
     currentDish,
     isProteinPhaseComplete,
     archiveDate,
-    gamePhase,
-    modalVisible,
-    toggleModal,
   } = useGameStore();
   const { isLoading } = useTodaysDish(archiveDate);
 
@@ -61,14 +57,6 @@ export function ProteinPhase() {
         guessResults={proteinGuessResults}
         actualProtein={currentDish.proteinPerServing}
       />
-
-      {gamePhase === "complete" && !modalVisible && (
-        <div className="flex justify-center mt-4">
-          <Button variant="cta" onClick={() => toggleModal(true)}>
-            📋 View Results
-          </Button>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/ArchiveDatePicker.tsx
+++ b/src/components/ArchiveDatePicker.tsx
@@ -31,8 +31,9 @@ export const ArchiveDatePicker: React.FC<ArchiveDatePickerProps> = ({
   const todayString = today.toISOString().split("T")[0];
 
   // Calculate the earliest available date (assuming game started 30 days ago for now)
+  const ARCHIVE_DAYS_BACK = 90;
   const earliestDate = new Date();
-  earliestDate.setDate(today.getDate() - 30);
+  earliestDate.setDate(today.getDate() - ARCHIVE_DAYS_BACK);
   const earliestDateString = earliestDate.toISOString().split("T")[0];
 
   const handleDateSelect = (date: string) => {
@@ -168,7 +169,7 @@ export const ArchiveDatePicker: React.FC<ArchiveDatePickerProps> = ({
           </DialogTitle>
           <DialogDescription>
             Select a date to play a previous game. You can only access games
-            from the last 30 days.
+            from the last 90 days.
           </DialogDescription>
         </DialogHeader>
 

--- a/src/components/GameHeader.tsx
+++ b/src/components/GameHeader.tsx
@@ -10,7 +10,7 @@ interface GameHeaderProps {
 }
 
 export function GameHeader({ onShowRules }: GameHeaderProps) {
-  const { isPlayingArchive, archiveDate, exitArchiveMode } = useGameStore();
+  const { isPlayingArchive, archiveDate, exitArchiveMode, streak } = useGameStore();
   const router = useRouter();
 
   const handleBackToToday = () => {
@@ -51,6 +51,17 @@ export function GameHeader({ onShowRules }: GameHeaderProps) {
         )}
       </div>
       <div className="flex items-center gap-3">
+        {streak >= 1 && !isPlayingArchive && (
+          <Link href="/statistics">
+            <div
+              className="flex items-center gap-1 px-2 py-1 bg-orange-100 hover:bg-orange-200 text-orange-700 rounded-md text-sm font-semibold transition-colors"
+              title={`${streak}-day streak`}
+            >
+              <span>🔥</span>
+              <span>{streak}</span>
+            </div>
+          </Link>
+        )}
         {showStatisticsButton && (
           <Link href="/statistics">
             <button

--- a/src/components/GameNavigation.tsx
+++ b/src/components/GameNavigation.tsx
@@ -143,9 +143,9 @@ export function ShowResultsButton({
           posthog.capture("toggle_recipe_modal", { opened: true });
         }}
         className="px-4 py-2"
-        variant="secondary"
+        variant="cta"
       >
-        Show Results
+        📋 View Results
       </Button>
     </div>
   );

--- a/src/components/GuessFeedback.tsx
+++ b/src/components/GuessFeedback.tsx
@@ -2,17 +2,28 @@
 
 import { useGameStore } from "@/store";
 import { AnimatePresence, motion } from "framer-motion";
+import { getCuisineRegion } from "@/data/cuisineRegions";
+import { RegionHintChip } from "./RegionHintChip";
 
 export const GuessFeedback = () => {
-  const { currentDish, gamePhase, revealedIngredients } = useGameStore();
+  const { currentDish, gamePhase, revealedIngredients, dishGuesses } = useGameStore();
 
   if (!currentDish) return null;
 
-  if (gamePhase === "dish" && revealedIngredients <= 1) return null;
+  const showIngredientHints =
+    gamePhase !== "country" && revealedIngredients >= 1;
+
+  const isDishPhase = gamePhase === "dish";
+  const region = isDishPhase ? getCuisineRegion(currentDish.country) : null;
+  const showRegionHint =
+    isDishPhase && dishGuesses.length >= 3 && region !== null;
+
+  // Early return only when there's truly nothing to show.
+  if (!showIngredientHints && !showRegionHint) return null;
 
   return (
-    <>
-      {gamePhase !== "country" && revealedIngredients >= 1 && (
+    <div className="flex flex-col gap-2">
+      {showIngredientHints && revealedIngredients > 1 && (
         <div className="flex flex-col gap-1">
           <div className="text-sm text-gray-600">Revealed Ingredients:</div>
           <div className="flex flex-wrap gap-1">
@@ -35,6 +46,8 @@ export const GuessFeedback = () => {
           </div>
         </div>
       )}
-    </>
+
+      {showRegionHint && region && <RegionHintChip region={region} />}
+    </div>
   );
 };

--- a/src/components/GuessInput.tsx
+++ b/src/components/GuessInput.tsx
@@ -162,10 +162,6 @@ export const GuessInput: React.FC<GuessInputProps> = memo(
       ? !isNaN(parseInt(input)) && parseInt(input) >= 0
       : !!input.trim();
 
-    const shouldShowGiveUp = isProteinPhase
-      ? previousProteinGuesses.length >= 3
-      : false;
-
     return (
       <div className="w-full flex gap-2 items-center">
         <GiveUpButton onGiveUp={handleGiveUp} />
@@ -215,19 +211,6 @@ export const GuessInput: React.FC<GuessInputProps> = memo(
             "Submit"
           )}
         </Button>
-
-        {shouldShowGiveUp && !isComplete && (
-          <div className="absolute top-full left-0 right-0 text-center mt-2">
-            <Button
-              onClick={handleGiveUp}
-              variant="outline"
-              size="sm"
-              className="text-xs"
-            >
-              Give up and see results
-            </Button>
-          </div>
-        )}
       </div>
     );
   }

--- a/src/components/RegionHintChip.tsx
+++ b/src/components/RegionHintChip.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { motion } from "framer-motion";
+import React from "react";
+
+interface RegionHintChipProps {
+  region: string;
+}
+
+export const RegionHintChip: React.FC<RegionHintChipProps> = ({ region }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="relative inline-flex items-center gap-2 self-start mt-2 px-3 py-1.5 rounded-full border border-indigo-300 bg-indigo-50 text-indigo-800 text-sm font-medium overflow-hidden animate-hint-glow"
+    >
+      <span aria-hidden>💡</span>
+      <span>
+        <span className="opacity-70 mr-1">Hint:</span>
+        {region}
+      </span>
+      <span className="absolute inset-0 pointer-events-none animate-hint-shimmer" />
+    </motion.div>
+  );
+};

--- a/src/components/ResultModal.tsx
+++ b/src/components/ResultModal.tsx
@@ -146,11 +146,16 @@ export const ResultModal: React.FC = memo(function ResultModal() {
       onOpenChange={(open) => {
         if (!open) {
           toggleModal(false);
+          setShowRecipe(false);
+          setShowSharePopover(false);
           posthog.capture("toggle_recipe_modal", { opened: false });
         }
       }}
     >
-      <DialogContent className="max-w-md w-full max-h-[90vh] overflow-y-auto gap-4 flex flex-col p-4 sm:p-6">
+      <DialogContent
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        className="max-w-md w-full max-h-[90vh] overflow-y-auto gap-4 flex flex-col p-4 sm:p-6"
+      >
         <div className="flex flex-col gap-1">
           <DialogTitle className="text-xl sm:text-2xl font-bold">
             🎉 You did it!

--- a/src/components/ResultModal.tsx
+++ b/src/components/ResultModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useGameStore } from "@/store";
 import Image from "next/image";
 import posthog from "posthog-js";
@@ -55,7 +56,7 @@ export const ResultModal: React.FC = memo(function ResultModal() {
     gameResults,
   ]);
 
-  if (gamePhase !== "complete" || !currentDish || !modalVisible) return null;
+  if (gamePhase !== "complete" || !currentDish) return null;
 
   const shareText = generateShareText({
     dishGuesses: gameResults.dishGuesses,
@@ -135,21 +136,19 @@ export const ResultModal: React.FC = memo(function ResultModal() {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-4 sm:p-6 max-w-full sm:max-w-md w-full max-h-[90vh] overflow-y-auto gap-4 flex flex-col">
+    <Dialog
+      open={modalVisible}
+      onOpenChange={(open) => {
+        if (!open) {
+          toggleModal(false);
+          posthog.capture("toggle_recipe_modal", { opened: false });
+        }
+      }}
+    >
+      <DialogContent className="max-w-md w-full max-h-[90vh] overflow-y-auto gap-4 flex flex-col p-4 sm:p-6">
         <div className="flex flex-col gap-1">
           <div className="flex justify-between items-center">
             <h2 className="text-xl sm:text-2xl font-bold">🎉 You did it!</h2>
-            <button
-              onClick={() => {
-                toggleModal(false);
-                posthog.capture("toggle_recipe_modal", { opened: false });
-              }}
-              className="text-gray-500 hover:text-gray-700 text-2xl sm:text-xl px-2"
-              aria-label="Close"
-            >
-              ✕
-            </button>
           </div>
           {streak >= 1 && (
             <div className="text-orange-500 font-semibold text-sm mt-2 animate-streak-pop">
@@ -254,7 +253,7 @@ export const ResultModal: React.FC = memo(function ResultModal() {
         <p className="text-center text-gray-500 text-sm mt-4">
           Come back tomorrow for a new challenge!
         </p>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 });

--- a/src/components/ResultModal.tsx
+++ b/src/components/ResultModal.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useGameStore } from "@/store";
 import Image from "next/image";
 import posthog from "posthog-js";
@@ -147,15 +152,18 @@ export const ResultModal: React.FC = memo(function ResultModal() {
     >
       <DialogContent className="max-w-md w-full max-h-[90vh] overflow-y-auto gap-4 flex flex-col p-4 sm:p-6">
         <div className="flex flex-col gap-1">
-          <div className="flex justify-between items-center">
-            <h2 className="text-xl sm:text-2xl font-bold">🎉 You did it!</h2>
-          </div>
+          <DialogTitle className="text-xl sm:text-2xl font-bold">
+            🎉 You did it!
+          </DialogTitle>
           {streak >= 1 && (
             <div className="text-orange-500 font-semibold text-sm mt-2 animate-streak-pop">
               🔥 You&apos;re on a {streak}-day streak!
             </div>
           )}
         </div>
+        <DialogDescription className="sr-only">
+          Game results for {currentDish.name} from {currentDish.country}.
+        </DialogDescription>
         {currentDish.imageUrl ? (
           <Image
             src={currentDish.imageUrl}

--- a/src/components/inputs/GiveUpButton.tsx
+++ b/src/components/inputs/GiveUpButton.tsx
@@ -8,7 +8,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import Image from "next/image";
 import { useState } from "react";
 
 interface GiveUpButtonProps {
@@ -42,18 +41,12 @@ export const GiveUpButton: React.FC<GiveUpButtonProps> = ({ onGiveUp }) => {
       </Dialog>
 
       <Button
-        className="p-1 sm:p-1.5 md:p-2"
-        variant="danger"
+        variant="outline"
+        size="sm"
         onClick={() => setGiveUpOpen(true)}
+        className="text-xs sm:text-sm whitespace-nowrap"
       >
-        <div className="w-5 h-5 sm:w-4 sm:h-4 md:w-5 md:h-5 lg:w-6 lg:h-6 relative">
-          <Image
-            src="/images/give-up.png"
-            alt="Give Up"
-            fill
-            className="object-contain"
-          />
-        </div>
+        🏳️ Give up
       </Button>
     </>
   );

--- a/src/components/inputs/GiveUpButton.tsx
+++ b/src/components/inputs/GiveUpButton.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -28,6 +29,9 @@ export const GiveUpButton: React.FC<GiveUpButtonProps> = ({ onGiveUp }) => {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Are you sure you want to give up?</DialogTitle>
+            <DialogDescription className="sr-only">
+              Giving up reveals the answer for the current phase and ends your guesses for it.
+            </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="default" onClick={() => setGiveUpOpen(false)}>

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -2,7 +2,7 @@
 
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
 import { useGameStore } from "../../store";
 
@@ -31,6 +31,16 @@ export const TextInput: React.FC<TextInputProps> = ({
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const { activePhase, isPhaseComplete } = useGameStore();
   const isComplete = isPhaseComplete(activePhase);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const isDesktop = window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+    if (isDesktop && !isComplete && !disabled) {
+      inputRef.current?.focus();
+    }
+  }, [isComplete, disabled]);
 
   const filteredSuggestions = suggestions
     .filter((suggestion) =>
@@ -132,6 +142,7 @@ export const TextInput: React.FC<TextInputProps> = ({
   return (
     <div className="flex-1 relative">
       <Input
+        ref={inputRef}
         type="text"
         value={value}
         onChange={(e) => handleInputChange(e.target.value)}

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -33,13 +33,19 @@ export const TextInput: React.FC<TextInputProps> = ({
   const isComplete = isPhaseComplete(activePhase);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const didAutofocusRef = useRef(false);
 
   useEffect(() => {
+    if (didAutofocusRef.current) return;
     if (typeof window === "undefined") return;
-    const isDesktop = window.matchMedia("(hover: hover) and (pointer: fine)").matches;
-    if (isDesktop && !isComplete && !disabled) {
-      inputRef.current?.focus();
-    }
+    // Skip touch-primary devices: avoids popping the soft keyboard before
+    // the player has seen the screen. Matches desktop + iPad-with-trackpad.
+    if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+    if (isComplete || disabled) return;
+    // Don't steal focus from a control the user has already engaged with.
+    if (document.activeElement && document.activeElement !== document.body) return;
+    inputRef.current?.focus();
+    didAutofocusRef.current = true;
   }, [isComplete, disabled]);
 
   const filteredSuggestions = suggestions

--- a/src/data/cuisineRegions.ts
+++ b/src/data/cuisineRegions.ts
@@ -1,0 +1,283 @@
+/**
+ * Cuisine-region map keyed by the `country` field on dishes.
+ * Used by the dish-phase progressive hint chip.
+ * Region labels are intentionally broad — the goal is to nudge the player
+ * toward the right corner of the world, not narrow the answer further.
+ *
+ * Naming note: where the dish DB might use either a short or long form
+ * (e.g. "USA" vs "United States of America", "Korea" vs "South Korea"),
+ * both variants are included so coverage stays high regardless of which
+ * form the AI-generated dishes use.
+ */
+export const CUISINE_REGIONS: Record<string, string> = {
+  // Iberian / Southern Europe
+  Portugal: "Iberian / Southern Europe",
+  Spain: "Iberian / Southern Europe",
+
+  // Mediterranean Europe
+  Italy: "Mediterranean Europe",
+  Greece: "Mediterranean Europe",
+  Malta: "Mediterranean Europe",
+  Cyprus: "Mediterranean Europe",
+
+  // Western Europe
+  France: "Western Europe",
+  Belgium: "Western Europe",
+  Netherlands: "Western Europe",
+  Luxembourg: "Western Europe",
+  Monaco: "Western Europe",
+
+  // Central Europe
+  Germany: "Central Europe",
+  Austria: "Central Europe",
+  Switzerland: "Central Europe",
+  Liechtenstein: "Central Europe",
+  Czechia: "Central Europe",
+  "Czech Republic": "Central Europe",
+  Slovakia: "Central Europe",
+  Hungary: "Central Europe",
+  Poland: "Central Europe",
+  Slovenia: "Central Europe",
+
+  // British Isles
+  "United Kingdom": "British Isles",
+  UK: "British Isles",
+  England: "British Isles",
+  Scotland: "British Isles",
+  Wales: "British Isles",
+  "Northern Ireland": "British Isles",
+  Ireland: "British Isles",
+
+  // Northern Europe / Scandinavia
+  Denmark: "Northern Europe / Scandinavia",
+  Sweden: "Northern Europe / Scandinavia",
+  Norway: "Northern Europe / Scandinavia",
+  Finland: "Northern Europe / Scandinavia",
+  Iceland: "Northern Europe / Scandinavia",
+  Estonia: "Northern Europe / Scandinavia",
+  Latvia: "Northern Europe / Scandinavia",
+  Lithuania: "Northern Europe / Scandinavia",
+
+  // Eastern Europe
+  Russia: "Eastern Europe",
+  Ukraine: "Eastern Europe",
+  Belarus: "Eastern Europe",
+  Moldova: "Eastern Europe",
+  Romania: "Eastern Europe",
+  Bulgaria: "Eastern Europe",
+
+  // Balkans (folded into Eastern Europe for the broad label)
+  Serbia: "Eastern Europe",
+  Croatia: "Eastern Europe",
+  "Bosnia and Herzegovina": "Eastern Europe",
+  Bosnia: "Eastern Europe",
+  Montenegro: "Eastern Europe",
+  Albania: "Eastern Europe",
+  Kosovo: "Eastern Europe",
+  "North Macedonia": "Eastern Europe",
+  Macedonia: "Eastern Europe",
+
+  // Anatolia / Eastern Mediterranean
+  Turkey: "Anatolia / Eastern Mediterranean",
+
+  // Caucasus
+  Armenia: "Caucasus",
+  Azerbaijan: "Caucasus",
+  Georgia: "Caucasus",
+
+  // Levant / Middle East
+  Lebanon: "Levant / Middle East",
+  Israel: "Levant / Middle East",
+  Palestine: "Levant / Middle East",
+  Syria: "Levant / Middle East",
+  Jordan: "Levant / Middle East",
+  Iraq: "Levant / Middle East",
+  Iran: "Levant / Middle East",
+
+  // Arabian Peninsula
+  "Saudi Arabia": "Arabian Peninsula",
+  "United Arab Emirates": "Arabian Peninsula",
+  UAE: "Arabian Peninsula",
+  Yemen: "Arabian Peninsula",
+  Oman: "Arabian Peninsula",
+  Qatar: "Arabian Peninsula",
+  Bahrain: "Arabian Peninsula",
+  Kuwait: "Arabian Peninsula",
+
+  // North Africa / Maghreb
+  Morocco: "North Africa / Maghreb",
+  Algeria: "North Africa / Maghreb",
+  Tunisia: "North Africa / Maghreb",
+  Libya: "North Africa / Maghreb",
+  Egypt: "North Africa / Maghreb",
+  Mauritania: "North Africa / Maghreb",
+  Sudan: "North Africa / Maghreb",
+
+  // Horn of Africa
+  Ethiopia: "Horn of Africa",
+  Eritrea: "Horn of Africa",
+  Somalia: "Horn of Africa",
+  Djibouti: "Horn of Africa",
+  "South Sudan": "Horn of Africa",
+
+  // West Africa
+  Nigeria: "West Africa",
+  Ghana: "West Africa",
+  Senegal: "West Africa",
+  "Ivory Coast": "West Africa",
+  "Côte d'Ivoire": "West Africa",
+  Mali: "West Africa",
+  "Burkina Faso": "West Africa",
+  Niger: "West Africa",
+  Guinea: "West Africa",
+  "Sierra Leone": "West Africa",
+  Liberia: "West Africa",
+  Togo: "West Africa",
+  Benin: "West Africa",
+  Gambia: "West Africa",
+  "Guinea-Bissau": "West Africa",
+  "Cape Verde": "West Africa",
+  Cameroon: "West Africa",
+
+  // East Africa
+  Kenya: "East Africa",
+  Tanzania: "East Africa",
+  Uganda: "East Africa",
+  Rwanda: "East Africa",
+  Burundi: "East Africa",
+  Madagascar: "East Africa",
+  Mauritius: "East Africa",
+  Seychelles: "East Africa",
+  Mozambique: "East Africa",
+  Malawi: "East Africa",
+
+  // Sub-Saharan / Southern Africa
+  "South Africa": "Sub-Saharan Africa",
+  Zimbabwe: "Sub-Saharan Africa",
+  Zambia: "Sub-Saharan Africa",
+  Botswana: "Sub-Saharan Africa",
+  Namibia: "Sub-Saharan Africa",
+  Lesotho: "Sub-Saharan Africa",
+  Eswatini: "Sub-Saharan Africa",
+  Swaziland: "Sub-Saharan Africa",
+  Angola: "Sub-Saharan Africa",
+  Congo: "Sub-Saharan Africa",
+  "Democratic Republic of the Congo": "Sub-Saharan Africa",
+  DRC: "Sub-Saharan Africa",
+  Gabon: "Sub-Saharan Africa",
+  "Equatorial Guinea": "Sub-Saharan Africa",
+  "Central African Republic": "Sub-Saharan Africa",
+  Chad: "Sub-Saharan Africa",
+
+  // South Asia
+  India: "South Asia",
+  Pakistan: "South Asia",
+  Bangladesh: "South Asia",
+  "Sri Lanka": "South Asia",
+  Nepal: "South Asia",
+  Bhutan: "South Asia",
+  Maldives: "South Asia",
+  Afghanistan: "South Asia",
+
+  // Central Asia
+  Kazakhstan: "Central Asia",
+  Uzbekistan: "Central Asia",
+  Turkmenistan: "Central Asia",
+  Kyrgyzstan: "Central Asia",
+  Tajikistan: "Central Asia",
+  Mongolia: "Central Asia",
+
+  // Southeast Asia
+  Thailand: "Southeast Asia",
+  Vietnam: "Southeast Asia",
+  Indonesia: "Southeast Asia",
+  Malaysia: "Southeast Asia",
+  Singapore: "Southeast Asia",
+  Philippines: "Southeast Asia",
+  Cambodia: "Southeast Asia",
+  Laos: "Southeast Asia",
+  Myanmar: "Southeast Asia",
+  Burma: "Southeast Asia",
+  Brunei: "Southeast Asia",
+  "East Timor": "Southeast Asia",
+  "Timor-Leste": "Southeast Asia",
+
+  // East Asia
+  Japan: "East Asia",
+  China: "East Asia",
+  Korea: "East Asia",
+  "South Korea": "East Asia",
+  "North Korea": "East Asia",
+  Taiwan: "East Asia",
+  "Hong Kong": "East Asia",
+  Macau: "East Asia",
+  Macao: "East Asia",
+  Tibet: "East Asia",
+
+  // North America
+  USA: "North America",
+  "United States": "North America",
+  "United States of America": "North America",
+  America: "North America",
+  Canada: "North America",
+
+  // Latin America
+  Mexico: "Latin America",
+  Guatemala: "Latin America",
+  Honduras: "Latin America",
+  "El Salvador": "Latin America",
+  Nicaragua: "Latin America",
+  "Costa Rica": "Latin America",
+  Panama: "Latin America",
+  Belize: "Latin America",
+  Colombia: "Latin America",
+  Venezuela: "Latin America",
+  Ecuador: "Latin America",
+  Peru: "Latin America",
+  Bolivia: "Latin America",
+  Brazil: "Latin America",
+  Chile: "Latin America",
+  Argentina: "Latin America",
+  Uruguay: "Latin America",
+  Paraguay: "Latin America",
+  Guyana: "Latin America",
+  Suriname: "Latin America",
+  "French Guiana": "Latin America",
+
+  // Caribbean
+  Cuba: "Caribbean",
+  Jamaica: "Caribbean",
+  "Dominican Republic": "Caribbean",
+  Haiti: "Caribbean",
+  "Puerto Rico": "Caribbean",
+  "Trinidad and Tobago": "Caribbean",
+  Trinidad: "Caribbean",
+  Barbados: "Caribbean",
+  Bahamas: "Caribbean",
+  "Antigua and Barbuda": "Caribbean",
+  Dominica: "Caribbean",
+  Grenada: "Caribbean",
+  "Saint Lucia": "Caribbean",
+  "Saint Kitts and Nevis": "Caribbean",
+  "Saint Vincent and the Grenadines": "Caribbean",
+
+  // Oceania
+  Australia: "Oceania",
+  "New Zealand": "Oceania",
+  Fiji: "Oceania",
+  "Papua New Guinea": "Oceania",
+  Samoa: "Oceania",
+  Tonga: "Oceania",
+  Vanuatu: "Oceania",
+  "Solomon Islands": "Oceania",
+  Kiribati: "Oceania",
+  Tuvalu: "Oceania",
+  Nauru: "Oceania",
+  Palau: "Oceania",
+  Micronesia: "Oceania",
+  "Marshall Islands": "Oceania",
+};
+
+export function getCuisineRegion(country: string): string | null {
+  return CUISINE_REGIONS[country] ?? null;
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,20 @@
+export async function register() {
+  // Node.js 22+ provides globalThis.localStorage as a Web Storage stub,
+  // but without --localstorage-file the methods are undefined, causing
+  // "localStorage.getItem is not a function" during SSR. Replace with a
+  // no-op so server renders don't crash — client-side code still gets
+  // the real browser localStorage.
+  if (
+    typeof (globalThis as Record<string, unknown>).localStorage !== "undefined" &&
+    typeof (globalThis.localStorage as Storage).getItem !== "function"
+  ) {
+    (globalThis as Record<string, unknown>).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    };
+  }
+}

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -144,7 +144,12 @@ EXAMPLE 2:
 
 Requirements:
 1. name: Must be exactly "${dishName}" (the dish name provided above)
-2. acceptableGuesses: 2-4 smart variations/alternative names people might use for "${dishName}"
+2. acceptableGuesses: 6-10 smart variations and alternative names people might use for "${dishName}". Include:
+   - Shortened or common-misname forms (e.g. "piri piri" for "Piri-piri Chicken").
+   - English vs. native-language names where both are commonly used.
+   - Singular and plural forms.
+   - Common alternate spellings and regional variants.
+   All entries lowercase, no duplicates.
 3. country: Country of origin (Title Case)
 4. ingredients: Exactly 6 key ingredients that give hints without being too obvious
 5. blurb: Appealing 1-2 sentence description that makes the dish sound delicious
@@ -288,7 +293,7 @@ Return ONLY a valid JSON object with the complete dish data for "${dishName}". N
       dishData &&
       typeof dishData.name === "string" &&
       Array.isArray(dishData.acceptableGuesses) &&
-      dishData.acceptableGuesses.length >= 1 &&
+      dishData.acceptableGuesses.length >= 6 &&
       typeof dishData.country === "string" &&
       Array.isArray(dishData.ingredients) &&
       dishData.ingredients.length === 6 &&

--- a/src/services/dishImageService.ts
+++ b/src/services/dishImageService.ts
@@ -80,85 +80,47 @@ class DishImageService {
     }
   }
 
-  /**
-   * Create an optimized prompt that matches your existing image style
-   */
   private createOptimizedPrompt(dishData: DishImageData): string {
     const { name, ingredients, country, blurb, tags } = dishData;
+    const text = [...tags, blurb].join(" ").toLowerCase();
+    const angle = this.getCameraAngle(text);
+    const surface = this.getSurface(text);
+    const cookingCue = this.getCookingCue(text);
+    const visibleIngredients = ingredients.slice(0, 3).join(", ");
 
-    // Base style that emphasizes centered composition
-    const baseStyle =
-      "professional food photography, centered composition with the dish as the main focal point, overhead or 45-degree elevated angle view, natural lighting, rustic wooden table or neutral background, high resolution, detailed textures, appetizing presentation, vibrant colors, perfectly centered in frame";
-
-    // Get dish-specific styling cues
-    const dishStyle = this.getDishStyle(tags, blurb);
-
-    // Focus on primary ingredients (first 3-4 for specificity)
-    const primaryIngredients = ingredients.slice(0, 4).join(", ");
-    const ingredientNote =
-      ingredients.length > 4
-        ? ` featuring ${primaryIngredients} among other ingredients`
-        : ` made with ${primaryIngredients}`;
-
-    return `A beautiful, appetizing photograph of ${name}, a traditional dish from ${country}${ingredientNote}. ${dishStyle}${baseStyle}. Restaurant-quality plating, mouth-watering presentation, dish positioned centrally in the frame. No text, watermarks, people, or artificial elements in the image.`;
+    return (
+      `${angle} photograph of ${name}, traditional dish from ${country}. ` +
+      `${cookingCue}, plated with ${visibleIngredients}. ` +
+      `Soft natural daylight from the left, ${surface} background, ` +
+      `shallow depth of field with the plate centered in frame. ` +
+      `Editorial food photography, 50mm lens, warm color grading, restaurant magazine quality.`
+    );
   }
 
-  /**
-   * Extract visual styling cues from tags and blurb
-   */
-  private getDishStyle(tags: string[], blurb: string): string {
-    const styles: string[] = [];
-    const allText = [...tags, blurb.toLowerCase()].join(" ").toLowerCase();
+  private getCameraAngle(text: string): string {
+    if (/(soup|stew|ramen|broth|curry)/.test(text)) return "45-degree close-up";
+    if (/(street food|handheld|sandwich|taco|burger|wrap)/.test(text)) return "Eye-level close-up";
+    return "Overhead";
+  }
 
-    // Cooking method styling
-    if (allText.includes("fried")) {
-      styles.push("golden brown crispy exterior with slight oil shine");
-    }
-    if (allText.includes("grilled")) {
-      styles.push("beautiful charred grill marks and smoky appearance");
-    }
-    if (allText.includes("steamed")) {
-      styles.push("moist tender texture with visible steam");
-    }
-    if (allText.includes("baked")) {
-      styles.push("golden brown crust from oven baking");
-    }
-    if (allText.includes("roasted")) {
-      styles.push("caramelized roasted exterior");
-    }
+  private getSurface(text: string): string {
+    if (/(fine dining|elegant|refined)/.test(text)) return "dark slate";
+    if (/(street food|market|casual)/.test(text)) return "weathered concrete";
+    return "rustic weathered wood";
+  }
 
-    // Texture and appearance
-    if (allText.includes("creamy") || allText.includes("rich")) {
-      styles.push("rich creamy sauce with smooth texture");
-    }
-    if (allText.includes("crispy") || allText.includes("crunchy")) {
-      styles.push("visible crispy crunchy textures");
-    }
-    if (allText.includes("fresh")) {
-      styles.push("bright fresh vibrant colors");
-    }
-    if (allText.includes("spicy") || allText.includes("hot")) {
-      styles.push("vibrant colors suggesting heat and spice");
-    }
-
-    // Presentation style
-    if (allText.includes("soup") || allText.includes("stew")) {
-      styles.push("served in a beautiful deep bowl with steam rising");
-    }
-    if (allText.includes("salad")) {
-      styles.push("fresh colorful vegetables with light glistening dressing");
-    }
-    if (allText.includes("noodles") || allText.includes("pasta")) {
-      styles.push("perfectly cooked noodles with visible texture");
-    }
-    if (allText.includes("rice")) {
-      styles.push("fluffy individual rice grains visible");
-    }
-    if (allText.includes("street food") || allText.includes("handheld")) {
-      styles.push("casual authentic street food presentation");
-    }
-
-    return styles.length > 0 ? styles.join(", ") + ". " : "";
+  private getCookingCue(text: string): string {
+    const cues: string[] = [];
+    if (/(grilled|bbq|charred)/.test(text)) cues.push("deep char marks, glossy marinade");
+    if (/fried/.test(text)) cues.push("golden brown crispy crust, light oil sheen");
+    if (/(baked|roasted)/.test(text)) cues.push("caramelized crust, deep golden tones");
+    if (/steamed/.test(text)) cues.push("tender moist surface, subtle steam rising");
+    if (/(creamy|rich)/.test(text)) cues.push("velvety sauce with glossy sheen");
+    if (/(noodles|pasta)/.test(text)) cues.push("perfectly twirled strands, sauce clinging to each");
+    if (/(soup|stew)/.test(text)) cues.push("rich broth catching the light, ingredients half-submerged");
+    if (/(spicy|hot)/.test(text)) cues.push("deep red and orange tones");
+    if (/(fresh|salad|raw)/.test(text)) cues.push("vibrant raw textures, glistening dressing");
+    return cues.length ? cues.join(", ") : "rich textures and natural colors";
   }
 
   /**

--- a/src/services/dishImageService.ts
+++ b/src/services/dishImageService.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import crypto from "crypto";
-import OpenAI from "openai";
+import { createDefaultImageGenerator, ImageGenerator } from "./imageGenerators";
 
 interface DishImageData {
   name: string;
@@ -12,20 +12,18 @@ interface DishImageData {
 
 interface ImageGenerationResult {
   imageUrl: string;
-  source: "dall-e-3";
+  source: string;
   cost: number;
   prompt: string;
   filename: string;
 }
 
 class DishImageService {
-  private openai: OpenAI;
+  private generator: ImageGenerator;
   private supabase: ReturnType<typeof createClient>;
 
   constructor() {
-    this.openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
-    });
+    this.generator = createDefaultImageGenerator();
 
     // Initialize Supabase client with service role key for storage operations
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -44,35 +42,19 @@ class DishImageService {
       console.log(`🎨 Generating image for: ${dishData.name}`);
 
       const prompt = this.createOptimizedPrompt(dishData);
-      console.log(`📝 Using prompt: ${prompt.substring(0, 100)}...`);
+      console.log(`📝 Using prompt: ${prompt.substring(0, 100)}…`);
 
-      const response = await this.openai.images.generate({
-        model: "dall-e-3",
-        prompt: prompt,
-        n: 1,
-        size: "1024x1024", // Keep 1024x1024 for good quality
-        quality: "standard", // Use standard instead of hd to reduce cost
-        style: "natural",
-      });
+      const result = await this.generator.generate(prompt, { width: 1536, height: 1024 });
 
-      const imageUrl = response.data?.[0]?.url;
-      if (!imageUrl) {
-        throw new Error("No image URL returned from DALL-E");
-      }
-
-      // Upload image to Supabase Storage
-      const { filename, publicUrl } = await this.uploadImageToSupabase(
-        imageUrl
-      );
-
+      const { filename, publicUrl } = await this.uploadImageToSupabase(result.url);
       console.log(`✅ Image generated and uploaded to Supabase: ${filename}`);
 
       return {
         imageUrl: publicUrl,
-        source: "dall-e-3",
-        cost: 0.04, // Current DALL-E 3 pricing for 1024x1024
-        prompt: prompt,
-        filename: filename,
+        source: result.source,
+        cost: result.cost,
+        prompt,
+        filename,
       };
     } catch (error) {
       console.error(`💥 Image generation failed for ${dishData.name}:`, error);
@@ -192,25 +174,14 @@ class DishImageService {
         ];
         const prompt = basePrompt + variations[i % variations.length];
 
-        const response = await this.openai.images.generate({
-          model: "dall-e-3",
-          prompt: prompt,
-          n: 1,
-          size: "1024x1024",
-          quality: "standard",
-          style: "natural",
-        });
+        const result = await this.generator.generate(prompt, { width: 1536, height: 1024 });
 
-        const imageUrl = response.data?.[0]?.url || "/images/404.png";
-
-        const { filename, publicUrl } = await this.uploadImageToSupabase(
-          imageUrl
-        );
+        const { filename, publicUrl } = await this.uploadImageToSupabase(result.url);
 
         results.push({
           imageUrl: publicUrl,
-          source: "dall-e-3",
-          cost: 0.04,
+          source: result.source,
+          cost: result.cost,
           prompt: prompt,
           filename: filename,
         });

--- a/src/services/imageGenerators/googleImagen4Ultra.ts
+++ b/src/services/imageGenerators/googleImagen4Ultra.ts
@@ -13,20 +13,15 @@ export class GoogleImagen4UltraGenerator implements ImageGenerator {
     this.ai = new GoogleGenAI({ apiKey: key });
   }
 
-  async generate(prompt: string, opts: ImageGenerationOpts): Promise<ImageGenerationResult> {
-    // Only 3:2 is supported by this generator right now (matches our tile aspect).
-    if (opts.width !== 1536 || opts.height !== 1024) {
-      throw new Error(
-        `GoogleImagen4UltraGenerator: unsupported size ${opts.width}x${opts.height}; expected 1536x1024 (3:2)`
-      );
-    }
-
+  async generate(prompt: string, _opts: ImageGenerationOpts): Promise<ImageGenerationResult> {
+    // Imagen 4 only supports 1:1, 9:16, 16:9, 4:3, 3:4. 4:3 is the closest to
+    // our 3:2 tile target; generateTiles cover-crops the small remainder.
     const result = await this.ai.models.generateImages({
       model: MODEL_ID,
       prompt,
       config: {
         numberOfImages: 1,
-        aspectRatio: "3:2",
+        aspectRatio: "4:3",
       },
     });
 

--- a/src/services/imageGenerators/googleImagen4Ultra.ts
+++ b/src/services/imageGenerators/googleImagen4Ultra.ts
@@ -1,0 +1,46 @@
+import { GoogleGenAI } from "@google/genai";
+import { ImageGenerator, ImageGenerationOpts, ImageGenerationResult } from "./types";
+
+const MODEL_ID = "imagen-4.0-ultra-generate-001";
+const COST_PER_IMAGE_USD = 0.06;
+
+export class GoogleImagen4UltraGenerator implements ImageGenerator {
+  private ai: GoogleGenAI;
+
+  constructor(apiKey?: string) {
+    const key = apiKey ?? process.env.GEMINI_API_KEY;
+    if (!key) throw new Error("GoogleImagen4UltraGenerator: missing GEMINI_API_KEY");
+    this.ai = new GoogleGenAI({ apiKey: key });
+  }
+
+  async generate(prompt: string, opts: ImageGenerationOpts): Promise<ImageGenerationResult> {
+    // Only 3:2 is supported by this generator right now (matches our tile aspect).
+    if (opts.width !== 1536 || opts.height !== 1024) {
+      throw new Error(
+        `GoogleImagen4UltraGenerator: unsupported size ${opts.width}x${opts.height}; expected 1536x1024 (3:2)`
+      );
+    }
+
+    const result = await this.ai.models.generateImages({
+      model: MODEL_ID,
+      prompt,
+      config: {
+        numberOfImages: 1,
+        aspectRatio: "3:2",
+      },
+    });
+
+    const imageBytes = result.generatedImages?.[0]?.image?.imageBytes;
+    if (!imageBytes) throw new Error("GoogleImagen4UltraGenerator: no image bytes returned");
+
+    // Convert base64 bytes to a data URL so the existing uploadImageToSupabase
+    // (which fetches the URL via fetch()) can consume it without code changes.
+    const url = `data:image/png;base64,${imageBytes}`;
+
+    return {
+      url,
+      cost: COST_PER_IMAGE_USD,
+      source: "imagen-4-ultra",
+    };
+  }
+}

--- a/src/services/imageGenerators/googleImagen4Ultra.ts
+++ b/src/services/imageGenerators/googleImagen4Ultra.ts
@@ -1,5 +1,5 @@
 import { GoogleGenAI } from "@google/genai";
-import { ImageGenerator, ImageGenerationOpts, ImageGenerationResult } from "./types";
+import { ImageGenerator, ImageGenerationResult } from "./types";
 
 const MODEL_ID = "imagen-4.0-ultra-generate-001";
 const COST_PER_IMAGE_USD = 0.06;
@@ -13,7 +13,7 @@ export class GoogleImagen4UltraGenerator implements ImageGenerator {
     this.ai = new GoogleGenAI({ apiKey: key });
   }
 
-  async generate(prompt: string, _opts: ImageGenerationOpts): Promise<ImageGenerationResult> {
+  async generate(prompt: string): Promise<ImageGenerationResult> {
     // Imagen 4 only supports 1:1, 9:16, 16:9, 4:3, 3:4. 4:3 is the closest to
     // our 3:2 tile target; generateTiles cover-crops the small remainder.
     const result = await this.ai.models.generateImages({

--- a/src/services/imageGenerators/index.ts
+++ b/src/services/imageGenerators/index.ts
@@ -1,0 +1,22 @@
+import { GoogleImagen4UltraGenerator } from "./googleImagen4Ultra";
+import { OpenAIDallE3Generator } from "./openaiDallE3";
+import { ImageGenerator } from "./types";
+
+export type { ImageGenerator, ImageGenerationOpts, ImageGenerationResult } from "./types";
+export { GoogleImagen4UltraGenerator, OpenAIDallE3Generator };
+
+/**
+ * Returns the configured default ImageGenerator.
+ * Set IMAGE_GENERATOR=dall-e-3 in env to fall back to the old path
+ * (e.g. for emergency rollback). Defaults to Imagen 4 Ultra.
+ */
+export function createDefaultImageGenerator(): ImageGenerator {
+  const which = (process.env.IMAGE_GENERATOR ?? "imagen-4-ultra").toLowerCase();
+  switch (which) {
+    case "dall-e-3":
+      return new OpenAIDallE3Generator();
+    case "imagen-4-ultra":
+    default:
+      return new GoogleImagen4UltraGenerator();
+  }
+}

--- a/src/services/imageGenerators/openaiDallE3.ts
+++ b/src/services/imageGenerators/openaiDallE3.ts
@@ -1,0 +1,35 @@
+import OpenAI from "openai";
+import { ImageGenerator, ImageGenerationOpts, ImageGenerationResult } from "./types";
+
+export class OpenAIDallE3Generator implements ImageGenerator {
+  private openai: OpenAI;
+
+  constructor(apiKey?: string) {
+    const key = apiKey ?? process.env.OPENAI_API_KEY;
+    if (!key) throw new Error("OpenAIDallE3Generator: missing OPENAI_API_KEY");
+    this.openai = new OpenAI({ apiKey: key });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async generate(prompt: string, _opts: ImageGenerationOpts): Promise<ImageGenerationResult> {
+    // DALL-E 3 only supports a fixed set of resolutions; we keep it on the
+    // historical 1024x1024 for backwards-compatibility with existing tiles.
+    const response = await this.openai.images.generate({
+      model: "dall-e-3",
+      prompt,
+      n: 1,
+      size: "1024x1024",
+      quality: "standard",
+      style: "natural",
+    });
+
+    const url = response.data?.[0]?.url;
+    if (!url) throw new Error("OpenAIDallE3Generator: no image URL returned");
+
+    return {
+      url,
+      cost: 0.04,
+      source: "dall-e-3",
+    };
+  }
+}

--- a/src/services/imageGenerators/types.ts
+++ b/src/services/imageGenerators/types.ts
@@ -1,0 +1,17 @@
+export interface ImageGenerationOpts {
+  width: number;
+  height: number;
+}
+
+export interface ImageGenerationResult {
+  /** Direct URL to the generated image (typically expires; consumers re-host). */
+  url: string;
+  /** Cost of this single generation in USD. */
+  cost: number;
+  /** Provider/model identifier for downstream tracking. */
+  source: string;
+}
+
+export interface ImageGenerator {
+  generate(prompt: string, opts: ImageGenerationOpts): Promise<ImageGenerationResult>;
+}

--- a/src/utils/gameHelpers.ts
+++ b/src/utils/gameHelpers.ts
@@ -262,6 +262,62 @@ export function getClosestGuess(
 }
 
 /**
+ * Returns the canonical match string when the input is a high-confidence match
+ * for one of the options. Used to auto-accept near-perfect fuzzy matches
+ * without showing a "did you mean?" prompt. Returns null when confidence is
+ * not high enough to auto-accept.
+ */
+export function getStrongFuzzyMatch(
+  input: string,
+  options: string[]
+): string | null {
+  const normalizedInput = input.toLowerCase().trim();
+  if (normalizedInput.length < 3) return null;
+
+  // Exact-substring containment: input is a substantial portion of an option,
+  // or an option is a substantial portion of input.
+  for (const option of options) {
+    const normalizedOption = option.toLowerCase();
+    if (
+      normalizedOption.includes(normalizedInput) &&
+      normalizedInput.length / normalizedOption.length >= 0.5
+    ) {
+      return option;
+    }
+    if (
+      normalizedInput.includes(normalizedOption) &&
+      normalizedOption.length / normalizedInput.length >= 0.5
+    ) {
+      return option;
+    }
+  }
+
+  // Very high-confidence fuzzy match (Fuse score <= 0.25 with a length-similarity
+  // guard catches near-perfect typos like "pirir piri chicken" → "piri-piri chicken"
+  // without letting short generic substrings like "chicken" through, because those
+  // have much lower length ratios to the target.
+  const fuse = new Fuse(options, {
+    threshold: 0.4,
+    includeScore: true,
+    ignoreLocation: false,
+    distance: 10,
+  });
+  const results = fuse.search(normalizedInput);
+  if (results.length === 0) return null;
+
+  const best = results[0];
+  const targetLen = best.item.length;
+  const lengthRatio =
+    Math.min(normalizedInput.length, targetLen) /
+    Math.max(normalizedInput.length, targetLen);
+  if ((best.score ?? 1) <= 0.25 && lengthRatio >= 0.7) {
+    return best.item;
+  }
+
+  return null;
+}
+
+/**
  * Intelligently reorders ingredients to avoid revealing dish name components early.
  * Moves ingredients that appear in acceptable guesses to positions 4-5.
  */


### PR DESCRIPTION
## Summary                                                                                                     
  Ships the four sections of [the game-experience-improvements                                                   
  design](docs/superpowers/specs/2026-05-22-game-experience-improvements-design.md):                             
  - **Small UX wins** — Radix-based results modal (Esc / outside-click dismiss + persistent "View Results"),     
  desktop-only autofocus, outline "🏳️  Give up" button, header streak chip, archive range 30 → 90 days.           
  - **Dish acceptance widening** — generator now produces 6–10 acceptable guesses per dish, runtime auto-accepts 
  very-high-confidence fuzzy matches via new `getStrongFuzzyMatch`; medium-confidence still falls back to the    
  "Did you mean?" toast.                                       
  - **Cuisine-region progressive hint** — new lavender "💡 Hint: {region}" chip appears below ingredient chips   
  after the 3rd wrong dish guess, with one-time shimmer + gentle glow.                                           
  - **Image-gen upgrade** — DALL-E 3 → Imagen 4 Ultra behind a new `ImageGenerator` adapter (env-flag rollback to
   DALL-E 3 via `IMAGE_GENERATOR=dall-e-3`); cinematographic prompt template replaces the old hedging adjectives.
                                                               
  ## Deviations from spec                                                                                        
  - Imagen 4 only accepts `1:1, 9:16, 16:9, 4:3, 3:4` — uses **4:3** instead of the planned 3:2. `generateTiles`'
   existing resize-cover branch handles the ~5% vertical crop on the way to 3:2 tiles.                           
  - `IMAGE_GENERATOR=dall-e-3` requires `OPENAI_API_KEY`; default path requires `GEMINI_API_KEY` (already added
  to the daily-generate workflow secrets — **needs to also be set as a repo secret** before next scheduled run). 
                                                               
  ## Test plan                                                                                                   
  - [x] Daily play-through: input autofocuses on desktop only, streak chip visible in header, give-up button
  reads `🏳️  Give up`.                                                                                            
  - [x] Make 3 wrong dish guesses on a country with a mapped region → hint chip appears with shimmer + glow.
  - [x] Type a short-form variant of a backfilled dish (e.g. `piri piri`) → auto-accepted; type an obvious typo →
   still gets "Did you mean?".                                                                                   
  - [x] Solve game → results modal opens, dismisses on Esc / outside-click / X; reopen via "View Results" without
   re-submitting score; close + reopen does not leave the recipe expanded.                                       
  - [x] Archive picker reaches 90 days back.                   
  - [x] `npm run daily-generate` (or scheduled workflow) produces a 4:3 image via Imagen 4 Ultra; tiles render   
  correctly in `dish-tiles`.                                                                                     
                                                   